### PR TITLE
Fix duplicate textures in exported GLB after resize

### DIFF
--- a/app/components/ThreeViewer.jsx
+++ b/app/components/ThreeViewer.jsx
@@ -430,45 +430,47 @@ const ThreeViewer = ({ currentResizeTexture = {} }) => {
     if (
       !currentResizeTexture ||
       !currentResizeTexture.src ||
-      !currentResizeTexture.materialName
+      !currentResizeTexture.uuid
     )
       return;
 
-    const textureLoader = new THREE.TextureLoader();
-    textureLoader.load(currentResizeTexture.src, (texture) => {
-      texture.colorSpace = THREE.SRGBColorSpace;
-
-      // テクスチャのUV設定を適切に設定
-      texture.wrapS = THREE.RepeatWrapping;
-      texture.wrapT = THREE.RepeatWrapping;
-      texture.repeat.set(1, 1);
-      texture.offset.set(0, 0);
-
-      // フィルタリング設定
-      texture.minFilter = THREE.LinearMipmapLinearFilter;
-      texture.magFilter = THREE.LinearFilter;
-
-      // テクスチャが反転しないように設定
-      texture.flipY = false;
-
+    const image = new Image();
+    image.onload = () => {
+      // Mutate the existing THREE.Texture in place so every material/slot
+      // referencing it picks up the new image. This avoids leaving the
+      // original texture reachable from other map slots, which would cause
+      // GLTFExporter to write both versions into the GLB.
+      const slots = [
+        "map",
+        "normalMap",
+        "roughnessMap",
+        "metalnessMap",
+        "emissiveMap",
+        "aoMap",
+        "displacementMap",
+        "alphaMap",
+        "envMap",
+      ];
+      const updatedUuids = new Set();
       materialsRef.current.forEach((material) => {
-        if (material.name === currentResizeTexture.materialName) {
-          // 元のテクスチャの設定を保持
-          const originalTexture = material.map;
-          if (originalTexture) {
-            // 元のテクスチャのUV設定をコピー
-            texture.wrapS = originalTexture.wrapS;
-            texture.wrapT = originalTexture.wrapT;
-            texture.repeat.copy(originalTexture.repeat);
-            texture.offset.copy(originalTexture.offset);
-            texture.flipY = originalTexture.flipY;
+        slots.forEach((slot) => {
+          const targetTexture = material[slot];
+          if (!targetTexture || targetTexture.uuid !== currentResizeTexture.uuid) return;
+          if (!updatedUuids.has(targetTexture.uuid)) {
+            targetTexture.image = image;
+            targetTexture.name = currentResizeTexture.name;
+            targetTexture.needsUpdate = true;
+            updatedUuids.add(targetTexture.uuid);
           }
-
-          material.map = texture;
           material.needsUpdate = true;
-        }
+        });
       });
-    });
+
+      if (rendererRef.current && sceneRef.current && cameraRef.current) {
+        rendererRef.current.render(sceneRef.current, cameraRef.current);
+      }
+    };
+    image.src = currentResizeTexture.src;
   }, [currentResizeTexture]);
 
   // マテリアルプロパティの動的変更


### PR DESCRIPTION
Match the resize target by texture uuid instead of material name and mutate the existing THREE.Texture in place. The previous code created a new texture and assigned it to a single material's .map, leaving the original texture reachable from other materials or map slots so GLTFExporter wrote both versions. Mutating the shared instance also preserves the original name on the resized texture.