### PR TITLE
Show and edit asset copyright in Statistics

### DIFF
--- a/app/classes/GLTFModel.ts
+++ b/app/classes/GLTFModel.ts
@@ -50,6 +50,10 @@ class GLTFModel {
     return [];
   }
 
+  getCopyright(): string {
+    return this.model?.asset?.copyright ?? "";
+  }
+
   getMaterials() {
     if(!this.model) return [];
     return this.modelMaterial.get(this.model);

--- a/app/components/ThreeViewer.jsx
+++ b/app/components/ThreeViewer.jsx
@@ -27,7 +27,11 @@ import {
   animationSeekTimeState,
   animationDurationState,
 } from "../state/atoms/CurrentSelect";
-import { selectedMaterialNameState, materialPropertiesState } from "../state/atoms/ModelInfo";
+import {
+  selectedMaterialNameState,
+  materialPropertiesState,
+  copyrightState,
+} from "../state/atoms/ModelInfo";
 import {
   detailModeEnabledState,
   meshTreeState,
@@ -39,6 +43,7 @@ import { useModelUpload } from "../hooks/useModelUpload";
 
 // utils
 import { buildMeshTree } from "../utils/buildMeshTree";
+import { injectGlbCopyright } from "../utils/injectGlbCopyright";
 
 // styles
 import styles from "../styles/components/viewer.module.scss";
@@ -63,6 +68,7 @@ const ThreeViewer = ({ currentResizeTexture = {} }) => {
   const setAnimationDuration = useSetRecoilState(animationDurationState);
   const selectedMaterialName = useRecoilValue(selectedMaterialNameState);
   const materialProperties = useRecoilValue(materialPropertiesState);
+  const copyright = useRecoilValue(copyrightState);
   const [detailModeEnabled, setDetailModeEnabled] = useRecoilState(detailModeEnabledState);
   const setMeshTree = useSetRecoilState(meshTreeState);
   const [selectedMeshUuid, setSelectedMeshUuid] = useRecoilState(selectedMeshUuidState);
@@ -594,7 +600,10 @@ const ThreeViewer = ({ currentResizeTexture = {} }) => {
     exporter.parse(
       modelRef.current,
       (gltf) => {
-        const blob = new Blob([gltf], { type: "application/octet-stream" });
+        const output = copyright
+          ? injectGlbCopyright(gltf, copyright)
+          : gltf;
+        const blob = new Blob([output], { type: "application/octet-stream" });
         const link = document.createElement("a");
         link.download = "gltf-light.glb";
         link.href = URL.createObjectURL(blob);
@@ -606,7 +615,7 @@ const ThreeViewer = ({ currentResizeTexture = {} }) => {
       },
       exportOptions
     );
-  }, []);
+  }, [copyright]);
 
   // ドラッグ&ドロップ
   const handleDragOver = useCallback((e) => {

--- a/app/components/icons/PencilIcon.jsx
+++ b/app/components/icons/PencilIcon.jsx
@@ -1,0 +1,20 @@
+import { memo } from "react";
+
+const PencilIcon = ({ size = 12 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M12 20h9" />
+    <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z" />
+  </svg>
+);
+
+export default memo(PencilIcon);

--- a/app/components/sidebar/Statistics.jsx
+++ b/app/components/sidebar/Statistics.jsx
@@ -1,17 +1,72 @@
 // lib
-import { Fragment, memo } from 'react';
-import { useRecoilValue } from 'recoil';
+import { Fragment, memo, useCallback, useRef, useState } from 'react';
+import { useRecoilValue, useRecoilState } from 'recoil';
 
 // states
-import { polygonCountState } from "../../state/atoms/ModelInfo";
+import {
+  polygonCountState,
+  copyrightState,
+  copyrightLockedState,
+} from "../../state/atoms/ModelInfo";
 import { upload3DModelSelector } from "../../state/selectors/Upload3DModelSelector";
 
 // components
 import TwoColumn from "../../layouts/TwoColumn"
+import PencilIcon from "../icons/PencilIcon";
+
+// styles
+import styles from "../../styles/components/statistics.module.scss";
 
 const Statistics = () => {
   const upload3DModel = useRecoilValue(upload3DModelSelector);
   const polygonCount = useRecoilValue(polygonCountState);
+  const [copyright, setCopyright] = useRecoilState(copyrightState);
+  const copyrightLocked = useRecoilValue(copyrightLockedState);
+  const [isEditing, setIsEditing] = useState(false);
+  const inputRef = useRef(null);
+
+  const onChangeCopyright = useCallback((event) => {
+    setCopyright(event.target.value);
+  }, [setCopyright]);
+
+  const onClickEdit = useCallback(() => {
+    setIsEditing(true);
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
+  }, []);
+
+  const onBlurInput = useCallback(() => {
+    setIsEditing(false);
+  }, []);
+
+  const renderCopyright = () => {
+    if (copyrightLocked) {
+      return <div className="text-overflow">{copyright}</div>;
+    }
+    return (
+      <div className={styles.copyrightField}>
+        <input
+          ref={inputRef}
+          type="text"
+          className={`${styles.copyrightInput} ${isEditing ? styles.copyrightInputActive : ""}`}
+          value={copyright}
+          onChange={onChangeCopyright}
+          onBlur={onBlurInput}
+          placeholder="—"
+          readOnly={!isEditing}
+        />
+        <button
+          type="button"
+          className={styles.copyrightEditButton}
+          onClick={onClickEdit}
+          aria-label="Edit copyright"
+        >
+          <PencilIcon />
+        </button>
+      </div>
+    );
+  };
 
   return (
     <Fragment>
@@ -31,6 +86,11 @@ const Statistics = () => {
           <TwoColumn
             left="Polygon:"
             right={polygonCount.toLocaleString()}
+            className="note"
+          />
+          <TwoColumn
+            left="Copyright:"
+            right={renderCopyright()}
             className="note"
           />
         </Fragment>

--- a/app/hooks/useModelUpload.js
+++ b/app/hooks/useModelUpload.js
@@ -8,6 +8,8 @@ import {
   polygonCountState,
   materialsState,
   texturesState,
+  copyrightState,
+  copyrightLockedState,
 } from "../state/atoms/ModelInfo";
 import { logsState } from "../state/atoms/Logs";
 import { upload3DModelSelector } from "../state/selectors/Upload3DModelSelector";
@@ -29,6 +31,8 @@ export function useModelUpload() {
   );
   const setMaterials = useSetRecoilState(materialsState);
   const setTextures = useSetRecoilState(texturesState);
+  const setCopyright = useSetRecoilState(copyrightState);
+  const setCopyrightLocked = useSetRecoilState(copyrightLockedState);
   const [logs, setLogs] = useRecoilState(logsState);
 
   const upload3DModel = new Upload3DModel();
@@ -53,6 +57,10 @@ export function useModelUpload() {
           }
           setPolygonCount(gltfModel.getPolygonCount());
 
+          const copyright = gltfModel.getCopyright();
+          setCopyright(copyright);
+          setCopyrightLocked(copyright !== "");
+
           const materials = gltfModel.getMaterials();
           setMaterials(materials);
 
@@ -73,6 +81,8 @@ export function useModelUpload() {
     [
       logs,
       setAnimations,
+      setCopyright,
+      setCopyrightLocked,
       setCurrentSelectAnimation,
       setLogs,
       setMaterials,

--- a/app/state/atoms/ModelInfo.ts
+++ b/app/state/atoms/ModelInfo.ts
@@ -15,6 +15,16 @@ export const polygonCountState = atom<number>({
   default: 0,
 });
 
+export const copyrightState = atom<string>({
+  key: "copyright",
+  default: "",
+});
+
+export const copyrightLockedState = atom<boolean>({
+  key: "copyrightLocked",
+  default: false,
+});
+
 export const materialsState = atom<Material[]>({
   key: "materials",
   default: [],

--- a/app/styles/components/statistics.module.scss
+++ b/app/styles/components/statistics.module.scss
@@ -1,0 +1,46 @@
+@import "../variables";
+@import "../mixin/animation";
+
+.copyrightField {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.copyrightInput {
+  flex: 1;
+  min-width: 0;
+  padding: 1px 4px;
+  border: solid 1px transparent;
+  box-sizing: border-box;
+  background: transparent;
+  color: $blue;
+  font: inherit;
+  font-weight: bold;
+  outline: none;
+  &::placeholder {
+    color: $blue;
+    opacity: 0.5;
+  }
+}
+
+.copyrightInputActive {
+  border-color: $light-blue;
+  background: $dark-blue;
+  color: $light-blue;
+}
+
+.copyrightEditButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border: none;
+  background: transparent;
+  color: $blue;
+  cursor: pointer;
+  @include ease-animation;
+  &:hover {
+    color: $light-blue;
+  }
+}

--- a/app/utils/injectGlbCopyright.ts
+++ b/app/utils/injectGlbCopyright.ts
@@ -1,0 +1,61 @@
+const GLB_MAGIC = 0x46546c67;
+const GLB_VERSION = 2;
+const CHUNK_TYPE_JSON = 0x4e4f534a;
+const GLB_HEADER_BYTES = 12;
+const CHUNK_HEADER_BYTES = 8;
+const JSON_PAD_BYTE = 0x20;
+
+export const injectGlbCopyright = (
+  buffer: ArrayBuffer,
+  copyright: string,
+): ArrayBuffer => {
+  const view = new DataView(buffer);
+  const magic = view.getUint32(0, true);
+  if (magic !== GLB_MAGIC) {
+    throw new Error("Invalid GLB: unexpected magic value");
+  }
+  const version = view.getUint32(4, true);
+  if (version !== GLB_VERSION) {
+    throw new Error(`Unsupported GLB version: ${version}`);
+  }
+  const totalLength = view.getUint32(8, true);
+
+  const jsonChunkLength = view.getUint32(GLB_HEADER_BYTES, true);
+  const jsonChunkType = view.getUint32(GLB_HEADER_BYTES + 4, true);
+  if (jsonChunkType !== CHUNK_TYPE_JSON) {
+    throw new Error("Invalid GLB: first chunk is not JSON");
+  }
+
+  const jsonStart = GLB_HEADER_BYTES + CHUNK_HEADER_BYTES;
+  const jsonBytes = new Uint8Array(buffer, jsonStart, jsonChunkLength);
+  const gltf = JSON.parse(new TextDecoder("utf-8").decode(jsonBytes));
+  if (!gltf.asset) gltf.asset = {};
+  gltf.asset.copyright = copyright;
+
+  const newJsonBytes = new TextEncoder().encode(JSON.stringify(gltf));
+  const padLength = (4 - (newJsonBytes.length % 4)) % 4;
+  const paddedJsonLength = newJsonBytes.length + padLength;
+  const paddedJson = new Uint8Array(paddedJsonLength);
+  paddedJson.set(newJsonBytes);
+  paddedJson.fill(JSON_PAD_BYTE, newJsonBytes.length);
+
+  const remainingStart = jsonStart + jsonChunkLength;
+  const remainingLength = totalLength - remainingStart;
+  const remaining = new Uint8Array(buffer, remainingStart, remainingLength);
+
+  const newTotalLength =
+    GLB_HEADER_BYTES + CHUNK_HEADER_BYTES + paddedJsonLength + remainingLength;
+  const output = new ArrayBuffer(newTotalLength);
+  const outputView = new DataView(output);
+  const outputBytes = new Uint8Array(output);
+
+  outputView.setUint32(0, GLB_MAGIC, true);
+  outputView.setUint32(4, GLB_VERSION, true);
+  outputView.setUint32(8, newTotalLength, true);
+  outputView.setUint32(GLB_HEADER_BYTES, paddedJsonLength, true);
+  outputView.setUint32(GLB_HEADER_BYTES + 4, CHUNK_TYPE_JSON, true);
+  outputBytes.set(paddedJson, jsonStart);
+  outputBytes.set(remaining, jsonStart + paddedJsonLength);
+
+  return output;
+};


### PR DESCRIPTION
Display the loaded model's asset.copyright in the sidebar Statistics panel. When the source model has no copyright, an inline editor lets the user write one, and the value is injected into the GLB on download.