### PR TITLE
Add material/texture deletion and fix texture editing

### DIFF
--- a/app/components/TextureResizeModal.jsx
+++ b/app/components/TextureResizeModal.jsx
@@ -3,7 +3,7 @@ import { memo, useEffect, useState, useCallback, useRef } from "react";
 import { useRecoilValue, useRecoilState } from "recoil";
 
 // states
-import { texturesState } from "../state/atoms/ModelInfo";
+import { texturesState, materialsState } from "../state/atoms/ModelInfo";
 import { currentSelectTextureState } from "../state/atoms/CurrentSelect";
 
 // classes
@@ -11,6 +11,9 @@ import ResizeTexture from "../classes/ResizeTexture";
 
 // components
 import TwoColumn from "../layouts/TwoColumn";
+
+// utils
+import { MATERIAL_TEXTURE_SLOTS } from "../utils/materialTextureSlots";
 
 // styles
 import styles from "../styles/components/textureResize.module.scss";
@@ -20,6 +23,7 @@ const TextureResizeModal = ({ setCurrentResizeTexture }) => {
     currentSelectTextureState
   );
   const [textures, setTextures] = useRecoilState(texturesState);
+  const materials = useRecoilValue(materialsState);
   const [resizeTexture, setResizeTexture] = useState(null);
   const [isShow, setIsShow] = useState(false);
 
@@ -38,9 +42,21 @@ const TextureResizeModal = ({ setCurrentResizeTexture }) => {
         width: size,
       });
       setResizeTexture(texture);
-      setCurrentResizeTexture(texture);
+
+      // このテクスチャが使われている全スロットを収集する。
+      // 同一テクスチャが複数マテリアル / 複数スロット（base color 以外も）で
+      // 共有されている場合に、正しいスロットへプレビュー反映するため。
+      const usages = [];
+      for (const material of materials) {
+        for (const slot of MATERIAL_TEXTURE_SLOTS) {
+          if (material[slot.key]?.uuid === currentTexture.uuid) {
+            usages.push({ materialName: material.name, slotKey: slot.key });
+          }
+        }
+      }
+      setCurrentResizeTexture({ ...texture, usages });
     },
-    [currentTexture]
+    [currentTexture, materials, setCurrentResizeTexture]
   );
 
   const onConfirm = useCallback(() => {
@@ -87,7 +103,7 @@ const TextureResizeModal = ({ setCurrentResizeTexture }) => {
         right={
           <div className={`note`}>
             <div className={styles.warning}>
-              Currently only textures used for base color are supported
+              Resizing updates every material slot that uses this texture.
             </div>
             <div style={{ marginBottom: "15px" }}>
               <h4 className={`sub-title`}>Current info</h4>

--- a/app/components/ThreeViewer.jsx
+++ b/app/components/ThreeViewer.jsx
@@ -715,49 +715,57 @@ const ThreeViewer = ({ currentResizeTexture = {} }) => {
     }
   }, [seekTime, setSeekTime, setAnimationCurrentTime]);
 
-  // テクスチャの動的変更
-    useEffect(() => {
-    if (
-      !currentResizeTexture ||
-      !currentResizeTexture.src ||
-      !currentResizeTexture.materialName
-    )
-      return;
+  // テクスチャの動的変更（リサイズ結果を該当スロットへ反映）
+  useEffect(() => {
+    if (!currentResizeTexture || !currentResizeTexture.src) return;
+
+    // usages: [{ materialName, slotKey }] — 同一テクスチャが複数スロット /
+    // マテリアルで共有される場合に対応する。後方互換として usages が無ければ
+    // base color(map) を対象にする。
+    const usages =
+      Array.isArray(currentResizeTexture.usages) && currentResizeTexture.usages.length > 0
+        ? currentResizeTexture.usages
+        : currentResizeTexture.materialName
+          ? [{ materialName: currentResizeTexture.materialName, slotKey: "map" }]
+          : [];
+    if (usages.length === 0) return;
 
     const textureLoader = new THREE.TextureLoader();
-    textureLoader.load(currentResizeTexture.src, (texture) => {
-      texture.colorSpace = THREE.SRGBColorSpace;
+    textureLoader.load(currentResizeTexture.src, (loaded) => {
+      loaded.minFilter = THREE.LinearMipmapLinearFilter;
+      loaded.magFilter = THREE.LinearFilter;
 
-      // テクスチャのUV設定を適切に設定
-      texture.wrapS = THREE.RepeatWrapping;
-      texture.wrapT = THREE.RepeatWrapping;
-      texture.repeat.set(1, 1);
-      texture.offset.set(0, 0);
+      usages.forEach(({ materialName, slotKey }) => {
+        materialsRef.current.forEach((material) => {
+          if (material.name !== materialName) return;
 
-      // フィルタリング設定
-      texture.minFilter = THREE.LinearMipmapLinearFilter;
-      texture.magFilter = THREE.LinearFilter;
-
-      // テクスチャが反転しないように設定
-      texture.flipY = false;
-
-      materialsRef.current.forEach((material) => {
-        if (material.name === currentResizeTexture.materialName) {
-          // 元のテクスチャの設定を保持
-          const originalTexture = material.map;
-          if (originalTexture) {
-            // 元のテクスチャのUV設定をコピー
-            texture.wrapS = originalTexture.wrapS;
-            texture.wrapT = originalTexture.wrapT;
-            texture.repeat.copy(originalTexture.repeat);
-            texture.offset.copy(originalTexture.offset);
-            texture.flipY = originalTexture.flipY;
+          // スロットごとに個別のテクスチャを割り当てる（色空間などがスロットで
+          // 異なり得るため）。元スロットの設定を引き継いで見た目を保つ。
+          const original = material[slotKey];
+          const texture = loaded.clone();
+          if (original) {
+            texture.wrapS = original.wrapS;
+            texture.wrapT = original.wrapT;
+            texture.repeat.copy(original.repeat);
+            texture.offset.copy(original.offset);
+            texture.flipY = original.flipY;
+            texture.colorSpace = original.colorSpace;
+            texture.channel = original.channel;
+          } else {
+            texture.flipY = false;
+            texture.colorSpace =
+              slotKey === "map" || slotKey === "emissiveMap"
+                ? THREE.SRGBColorSpace
+                : THREE.NoColorSpace;
           }
+          texture.needsUpdate = true;
 
-          material.map = texture;
+          material[slotKey] = texture;
           material.needsUpdate = true;
-        }
+        });
       });
+
+      if (composerRef.current) composerRef.current.render();
     });
   }, [currentResizeTexture]);
 

--- a/app/components/ThreeViewer.jsx
+++ b/app/components/ThreeViewer.jsx
@@ -35,6 +35,8 @@ import {
   polygonReductionRatioState,
   hasSkinnedMeshState,
   wireframeOverlayEnabledState,
+  deleteMaterialCommandState,
+  deleteTextureSlotCommandState,
 } from "../state/atoms/ModelInfo";
 import {
   detailModeEnabledState,
@@ -93,6 +95,8 @@ const ThreeViewer = ({ currentResizeTexture = {} }) => {
   const copyright = useRecoilValue(copyrightState);
   const polygonReductionRatio = useRecoilValue(polygonReductionRatioState);
   const wireframeOverlayEnabled = useRecoilValue(wireframeOverlayEnabledState);
+  const deleteMaterialCommand = useRecoilValue(deleteMaterialCommandState);
+  const deleteTextureSlotCommand = useRecoilValue(deleteTextureSlotCommandState);
   const setPolygonCount = useSetRecoilState(polygonCountState);
   const setHasSkinnedMesh = useSetRecoilState(hasSkinnedMeshState);
   const [detailModeEnabled, setDetailModeEnabled] = useRecoilState(detailModeEnabledState);
@@ -116,6 +120,7 @@ const ThreeViewer = ({ currentResizeTexture = {} }) => {
   const reduceTimeoutRef = useRef(null);
   const wireframeGroupRef = useRef(null);
   const wireframeEnabledRef = useRef(false);
+  const blankMaterialRef = useRef(null);
   const isPlayingRef = useRef(true);
   const animationDurationRef = useRef(0);
   const throttledSetTimeRef = useRef(null);
@@ -444,6 +449,11 @@ const ThreeViewer = ({ currentResizeTexture = {} }) => {
               }
             }
           });
+
+          if (blankMaterialRef.current) {
+            blankMaterialRef.current.dispose();
+            blankMaterialRef.current = null;
+          }
         }
 
         // 新しいモデルの追加
@@ -613,6 +623,56 @@ const ThreeViewer = ({ currentResizeTexture = {} }) => {
     wireframeEnabledRef.current = wireframeOverlayEnabled;
     rebuildWireframeOverlay();
   }, [wireframeOverlayEnabled, rebuildWireframeOverlay]);
+
+  // マテリアル削除: 対象マテリアルを使っているメッシュを共有の無地マテリアルに差し替える。
+  useEffect(() => {
+    if (!deleteMaterialCommand || !modelRef.current) return;
+    const { materialName } = deleteMaterialCommand;
+
+    if (!blankMaterialRef.current) {
+      blankMaterialRef.current = new THREE.MeshStandardMaterial({
+        name: "__blank__",
+        color: 0x888888,
+        roughness: 1,
+        metalness: 0,
+      });
+    }
+
+    modelRef.current.traverse((child) => {
+      if (!child.isMesh) return;
+      if (Array.isArray(child.material)) {
+        child.material = child.material.map((m) =>
+          m.name === materialName ? blankMaterialRef.current : m
+        );
+      } else if (child.material.name === materialName) {
+        child.material = blankMaterialRef.current;
+      }
+    });
+
+    rebuildWireframeOverlay();
+    if (composerRef.current) composerRef.current.render();
+  }, [deleteMaterialCommand, rebuildWireframeOverlay]);
+
+  // テクスチャスロット削除: 対象スロットを null にして GPU リソースを解放する。
+  useEffect(() => {
+    if (!deleteTextureSlotCommand || !modelRef.current) return;
+    const { materialName, slotKey } = deleteTextureSlotCommand;
+
+    modelRef.current.traverse((child) => {
+      if (!child.isMesh) return;
+      const mats = Array.isArray(child.material) ? child.material : [child.material];
+      for (const m of mats) {
+        if (m.name !== materialName) continue;
+        if (m[slotKey]) {
+          m[slotKey].dispose();
+          m[slotKey] = null;
+          m.needsUpdate = true;
+        }
+      }
+    });
+
+    if (composerRef.current) composerRef.current.render();
+  }, [deleteTextureSlotCommand]);
 
   // アニメーション制御（複数同時再生対応）
   useEffect(() => {

--- a/app/components/icons/TrashIcon.jsx
+++ b/app/components/icons/TrashIcon.jsx
@@ -1,0 +1,23 @@
+import { memo } from "react";
+
+const TrashIcon = ({ size = 12 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <polyline points="3 6 5 6 21 6" />
+    <path d="M19 6l-1 14H6L5 6" />
+    <path d="M10 11v6" />
+    <path d="M14 11v6" />
+    <path d="M9 6V4h6v2" />
+  </svg>
+);
+
+export default memo(TrashIcon);

--- a/app/components/sidebar/Materials.jsx
+++ b/app/components/sidebar/Materials.jsx
@@ -1,6 +1,6 @@
 // lib
-import { memo, Fragment, useCallback, useMemo, useState } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { memo, Fragment, useCallback, useMemo, useRef, useState } from 'react';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
 // states
 import {
@@ -8,7 +8,9 @@ import {
   selectedMaterialNameState,
   materialPropertiesState,
   texturesState,
-  updateMaterialProperty
+  updateMaterialProperty,
+  deleteMaterialCommandState,
+  deleteTextureSlotCommandState,
 } from "../../state/atoms/ModelInfo";
 
 // hooks
@@ -16,17 +18,45 @@ import { useSelectMaterialByName } from "../../hooks/useSelectMaterialByName";
 
 // components
 import MaterialIcon from "../icons/MaterialIcon";
+import TrashIcon from "../icons/TrashIcon";
 
 // utils
-import { MATERIAL_TEXTURE_SLOTS } from "../../utils/materialTextureSlots";
+import { MATERIAL_TEXTURE_SLOTS, getMaterialTextureUuids } from "../../utils/materialTextureSlots";
+
+const getAllUsedTextureUuids = (materials) => {
+  const uuids = new Set();
+  for (const material of materials) {
+    for (const uuid of getMaterialTextureUuids(material)) {
+      uuids.add(uuid);
+    }
+  }
+  return uuids;
+};
+
+const deleteButtonStyle = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexShrink: 0,
+  padding: '2px',
+  border: 'none',
+  background: 'transparent',
+  color: 'rgba(255,80,80,0.7)',
+  cursor: 'pointer',
+  borderRadius: '2px',
+  lineHeight: 1,
+};
 
 const Materials = () => {
   const [materials, setMaterials] = useRecoilState(materialsState);
-  const textures = useRecoilValue(texturesState);
-  const selectedMaterialName = useRecoilValue(selectedMaterialNameState);
+  const [textures, setTextures] = useRecoilState(texturesState);
+  const [selectedMaterialName, setSelectedMaterialName] = useRecoilState(selectedMaterialNameState);
   const [materialProperties, setMaterialProperties] = useRecoilState(materialPropertiesState);
+  const setDeleteMaterialCommand = useSetRecoilState(deleteMaterialCommandState);
+  const setDeleteTextureSlotCommand = useSetRecoilState(deleteTextureSlotCommandState);
   const selectMaterialByName = useSelectMaterialByName();
   const [expandOverrides, setExpandOverrides] = useState({});
+  const serialRef = useRef(0);
 
   const texturesByUuid = useMemo(() => {
     const lookup = new Map();
@@ -69,6 +99,51 @@ const Materials = () => {
       setMaterials((prev) => updateMaterialProperty(prev, selectedMaterialName, "metalness", value));
     }
   }, [setMaterialProperties, selectedMaterialName, setMaterials]);
+
+  const handleDeleteMaterial = useCallback((materialName) => {
+    if (!window.confirm(`Delete material "${materialName}"?\nMeshes using it will become blank. This cannot be undone.`)) return;
+
+    const target = materials.find((m) => m.name === materialName);
+    const deletedUuids = getMaterialTextureUuids(target);
+    const remaining = materials.filter((m) => m.name !== materialName);
+    const remainingUuids = getAllUsedTextureUuids(remaining);
+    const orphanUuids = new Set([...deletedUuids].filter((u) => !remainingUuids.has(u)));
+
+    if (selectedMaterialName === materialName) setSelectedMaterialName(null);
+    setMaterials(remaining);
+    setTextures((prev) => prev.filter((t) => !orphanUuids.has(t.uuid)));
+    setDeleteMaterialCommand({ materialName, id: ++serialRef.current });
+  }, [materials, selectedMaterialName, setSelectedMaterialName, setMaterials, setTextures, setDeleteMaterialCommand]);
+
+  const handleDeleteTextureSlot = useCallback((materialName, slotKey, slotLabel) => {
+    if (!window.confirm(`Delete the ${slotLabel} texture from material "${materialName}"?\nThis cannot be undone.`)) return;
+
+    const target = materials.find((m) => m.name === materialName);
+    const deletedUuid = target?.[slotKey]?.uuid;
+
+    // Check if this uuid is used elsewhere (other materials or other slots of the same material).
+    const usedElsewhere = materials.some((m) => {
+      if (m.name === materialName) {
+        return MATERIAL_TEXTURE_SLOTS.some(
+          (slot) => slot.key !== slotKey && m[slot.key]?.uuid === deletedUuid
+        );
+      }
+      return getMaterialTextureUuids(m).has(deletedUuid);
+    });
+
+    // Mutate the sidebar-side material object so the thumbnail disappears immediately.
+    setMaterials((prev) => {
+      const mat = prev.find((m) => m.name === materialName);
+      if (mat) mat[slotKey] = null;
+      return [...prev];
+    });
+
+    if (deletedUuid && !usedElsewhere) {
+      setTextures((prev) => prev.filter((t) => t.uuid !== deletedUuid));
+    }
+
+    setDeleteTextureSlotCommand({ materialName, slotKey, id: ++serialRef.current });
+  }, [materials, setMaterials, setTextures, setDeleteTextureSlotCommand]);
 
   return (
     <Fragment>
@@ -133,7 +208,15 @@ const Materials = () => {
               <span style={{ display: 'inline-flex', flexShrink: 0 }}>
                 <MaterialIcon size={14} />
               </span>
-              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{material.name}</span>
+              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', flex: 1 }}>{material.name}</span>
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); handleDeleteMaterial(material.name); }}
+                title="Delete material"
+                style={deleteButtonStyle}
+              >
+                <TrashIcon size={12} />
+              </button>
             </div>
             {hasTextures && isExpanded && (
               <ul
@@ -150,6 +233,7 @@ const Materials = () => {
                   <li
                     key={entry.key}
                     style={{
+                      position: 'relative',
                       display: 'flex',
                       flexDirection: 'column',
                       alignItems: 'center',
@@ -169,6 +253,26 @@ const Materials = () => {
                         objectFit: 'cover',
                       }}
                     />
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteTextureSlot(material.name, entry.key, entry.label)}
+                      title={`Delete ${entry.label} texture`}
+                      style={{
+                        position: 'absolute',
+                        top: '2px',
+                        right: '4px',
+                        padding: '1px',
+                        border: 'none',
+                        background: 'rgba(0,0,0,0.55)',
+                        color: 'rgba(255,80,80,0.85)',
+                        cursor: 'pointer',
+                        borderRadius: '2px',
+                        lineHeight: 1,
+                        display: 'flex',
+                      }}
+                    >
+                      <TrashIcon size={10} />
+                    </button>
                     <span
                       style={{
                         overflow: 'hidden',

--- a/app/state/atoms/ModelInfo.ts
+++ b/app/state/atoms/ModelInfo.ts
@@ -44,6 +44,18 @@ export const wireframeOverlayEnabledState = atom<boolean>({
   default: false,
 });
 
+// Commands to delete a material or a single texture slot in the Three.js scene.
+// The id field ensures the useEffect fires even when the same target is deleted twice.
+export const deleteMaterialCommandState = atom<{ materialName: string; id: number } | null>({
+  key: "deleteMaterialCommand",
+  default: null,
+});
+
+export const deleteTextureSlotCommandState = atom<{ materialName: string; slotKey: string; id: number } | null>({
+  key: "deleteTextureSlotCommand",
+  default: null,
+});
+
 export const copyrightState = atom<string>({
   key: "copyright",
   default: "",

--- a/app/state/atoms/ModelInfo.ts
+++ b/app/state/atoms/ModelInfo.ts
@@ -69,6 +69,9 @@ export const copyrightLockedState = atom<boolean>({
 export const materialsState = atom<Material[]>({
   key: "materials",
   default: [],
+  // Holds live THREE.Material instances that are mutated in place (properties,
+  // texture slots), so opt out of Recoil's dev-mode deep freeze.
+  dangerouslyAllowMutability: true,
 })
 
 export const texturesState = atom<TextureType[]>({


### PR DESCRIPTION
## Summary

Adds material and texture deletion for model size reduction, and fixes two texture-editing issues surfaced along the way. All operations reflect in the live preview and in the `Download glTF` export.

## Changes

### Material / texture deletion (`eb2f8c7`)
- Trash buttons on each material row and on individual texture thumbnails in the sidebar, with a `window.confirm` guard.
- **Material deletion**: meshes using it are reassigned to a shared blank `MeshStandardMaterial` so geometry is kept while all textures are dropped. Multiple deleted materials share the same blank instance to reduce material count.
- **Texture slot deletion**: nulls the specific slot (`map`, `normalMap`, …) and disposes the GPU texture.
- Orphaned textures (no longer referenced by any remaining material) are removed from the sidebar list to stay in sync.

### Fix read-only error when mutating materials (`afb3525`)
- Recoil deep-freezes atom values in development, so mutating a `THREE.Material` stored in `materialsState` threw `Cannot assign to read only property`. This also affected the existing roughness/metalness sliders.
- Opted the atom out of the freeze with `dangerouslyAllowMutability`, since it intentionally holds live, mutable material instances.

### Apply texture resize to the correct slots (`fe245ec`)
- Resizing a non-base-color texture (roughness, normal, …) previously replaced the base color map in the preview because the viewer always assigned the resized image to `material.map`.
- Now collects every `(materialName, slotKey)` referencing the texture by uuid and updates each actual slot — handling a single texture shared across multiple materials/slots — while preserving each slot's original settings (wrap, repeat, offset, flipY, colorSpace, channel).

## Test plan
- [x] Delete a material → meshes turn blank, material count drops, orphaned textures removed; preview and export reflect it.
- [x] Delete a single texture slot → thumbnail disappears, shared texture kept until its last reference is removed.
- [x] Adjust roughness/metalness sliders → no read-only error in dev.
- [x] Resize a non-base-color texture → the correct slot updates in the preview; base color is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)