### PR TITLE
0-2: Enforce zero cross-references between legacy and v2 (lint + CI)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,22 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "import/no-restricted-paths": [
+      "error",
+      {
+        "zones": [
+          {
+            "target": "./app/(v2)",
+            "from": "./app/(legacy)",
+            "message": "v2 code must not import legacy code. Keep the two versions fully decoupled (copy shared logic into v2 instead of importing)."
+          },
+          {
+            "target": "./app/(legacy)",
+            "from": "./app/(v2)",
+            "message": "legacy code must not import v2 code. The legacy app is frozen and must stay independent."
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - main
 
 jobs:
-  test:
+  verify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,5 +13,6 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - run: npm run lint
       - run: npm test
       - run: npm run build


### PR DESCRIPTION
## 概要

旧版 `(legacy)` と新版 `(v2)` の相互参照ゼロを機械的に強制する (PRD F-20 / 受け入れ基準 §5-8, architecture.md §3.3)。

## 変更内容

- **ESLint `import/no-restricted-paths`** (`.eslintrc.json`): route group 境界を跨ぐ import を双方向で **error** 化。
  - `app/(v2)/**` → `app/(legacy)/**` を禁止
  - `app/(legacy)/**` → `app/(v2)/**` を禁止
  - `eslint-config-next` に同梱の `eslint-plugin-import` を利用（追加依存なし）。route group 名の括弧 `()` は `is-glob` 上リテラル扱いのためパス封鎖として正しく機能する。
- **CI** (`.github/workflows/ci.yml`): 全 PR で自動実行し、`lint` を追加して `lint → test → build` を実行。trigger を `main` 限定から全 `pull_request` へ拡張（`feature/v2` 系ブランチもカバー）。

## 動作確認 (QA)

- ✅ `(v2)→(legacy)` / `(legacy)→(v2)` の違反 import プローブを一時作成 → 双方向で lint **error**、`npm run lint` 終了コード 1。プローブ削除後は終了コード 0 に復帰。
- ✅ `(legacy)` を app 外へ一時退避 → `next build` 成功（v2 が空のため 404 のみ、exit 0）。ダングリング import なしを構造的に確認。
- ✅ 通常状態で `npm test` 48 件緑・`next build` 成功。既存 legacy の警告は Warning 止まりで CI を落とさない。

Closes #27