### PR TITLE
1-1: 3D表示層(素three.js薄ラップ)の新規実装

### DIFF
--- a/app/(v2)/components/FileDropzone.module.scss
+++ b/app/(v2)/components/FileDropzone.module.scss
@@ -6,6 +6,13 @@
   width: min(600px, 100%);
 }
 
+// Hero: fill the whole preview area so the drop target is large.
+.wrapperHero {
+  flex: 1;
+  align-self: stretch;
+  width: 100%;
+}
+
 .dropzone {
   display: flex;
   flex-direction: column;
@@ -27,6 +34,11 @@
     border-color: var(--color-highlight);
     background: var(--color-bg);
   }
+}
+
+.dropzoneHero {
+  flex: 1;
+  gap: var(--space-18);
 }
 
 .icon {

--- a/app/(v2)/components/FileDropzone.tsx
+++ b/app/(v2)/components/FileDropzone.tsx
@@ -5,17 +5,24 @@ import { useModelUpload } from "../hooks/useModelUpload";
 import { UploadIcon } from "../icons";
 import styles from "./FileDropzone.module.scss";
 
+interface FileDropzoneProps {
+  /** `panel` = compact (sidebar); `hero` = fills the preview area (empty state). */
+  variant?: "panel" | "hero";
+}
+
 /** Upload dropzone: click or drag & drop a `.glb` into modelStore. */
-export function FileDropzone() {
+export function FileDropzone({ variant = "panel" }: FileDropzoneProps) {
   const { acceptFiles, error } = useModelUpload();
   const inputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
 
   return (
-    <div className={styles.wrapper}>
+    <div className={`${styles.wrapper} ${variant === "hero" ? styles.wrapperHero : ""}`}>
       <button
         type="button"
-        className={`${styles.dropzone} ${isDragging ? styles.dragging : ""}`}
+        className={`${styles.dropzone} ${variant === "hero" ? styles.dropzoneHero : ""} ${
+          isDragging ? styles.dragging : ""
+        }`}
         onClick={() => inputRef.current?.click()}
         onDragOver={(event) => {
           event.preventDefault();

--- a/app/(v2)/page.tsx
+++ b/app/(v2)/page.tsx
@@ -37,7 +37,7 @@ export default function V2Page() {
             <Stage />
           ) : (
             <div className={styles.viewerBody}>
-              <FileDropzone />
+              <FileDropzone variant="hero" />
             </div>
           )}
           <Copyright />

--- a/app/(v2)/page.tsx
+++ b/app/(v2)/page.tsx
@@ -6,6 +6,7 @@ import { ServiceInfo } from "./components/ServiceInfo";
 import { FileDropzone } from "./components/FileDropzone";
 import { ModelSummaryCard } from "./components/ModelSummaryCard";
 import { Copyright } from "./components/Copyright";
+import { Stage } from "./viewer/Stage";
 import styles from "./styles/page.module.scss";
 
 /**
@@ -32,13 +33,13 @@ export default function V2Page() {
           )}
         </aside>
         <section className={styles.viewer} aria-label="3Dビュー">
-          <div className={styles.viewerBody}>
-            {hasModel ? (
-              <p className={styles.viewerNote}>3Dビューアは今後のステップで実装されます</p>
-            ) : (
+          {hasModel ? (
+            <Stage />
+          ) : (
+            <div className={styles.viewerBody}>
               <FileDropzone />
-            )}
-          </div>
+            </div>
+          )}
           <Copyright />
         </section>
       </main>

--- a/app/(v2)/styles/page.module.scss
+++ b/app/(v2)/styles/page.module.scss
@@ -27,10 +27,3 @@
   justify-content: center;
   padding: var(--space-20);
 }
-
-.viewerNote {
-  margin: 0;
-  color: var(--color-text-faint);
-  font-size: var(--font-size-11);
-  line-height: 14px;
-}

--- a/app/(v2)/styles/tokens.scss
+++ b/app/(v2)/styles/tokens.scss
@@ -23,6 +23,9 @@
   --radius-md: 10px;
   --radius-pill: 100px;
 
+  // Elevation (floating controls over the 3D canvas)
+  --shadow-sm: 0 1px 2px rgba(38, 36, 31, 0.06), 0 2px 8px rgba(38, 36, 31, 0.08);
+
   // Spacing (Figma spacer scale + 8pt rhythm)
   --space-2: 2px;
   --space-4: 4px;
@@ -60,4 +63,6 @@
   --color-text: #f4ede2;
   --color-text-muted: #b3a99c;
   --color-text-faint: #8f887c;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.5);
 }

--- a/app/(v2)/viewer/Stage.module.scss
+++ b/app/(v2)/viewer/Stage.module.scss
@@ -1,0 +1,31 @@
+.stage {
+  flex: 1;
+  position: relative;
+  min-height: 0;
+}
+
+.canvas {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  touch-action: none;
+
+  :global(canvas) {
+    display: block;
+  }
+}
+
+.selected {
+  position: absolute;
+  top: var(--space-12);
+  left: var(--space-12);
+  z-index: 1;
+  padding: var(--space-4) var(--space-8);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  box-shadow: var(--shadow-sm);
+}

--- a/app/(v2)/viewer/Stage.tsx
+++ b/app/(v2)/viewer/Stage.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useModelStore } from "../store/modelStore";
+import { useThreeStage } from "./useThreeStage";
+import { ViewerToolbar } from "./ViewerToolbar";
+import styles from "./Stage.module.scss";
+
+/** 3D preview of the uploaded glb, driven by the `useThreeStage` hook. */
+export function Stage() {
+  const bytes = useModelStore((state) => state.originalBytes);
+  const {
+    containerRef,
+    animations,
+    isPlaying,
+    selectedName,
+    onPointerDown,
+    onPointerUp,
+    togglePlay,
+    resetView,
+  } = useThreeStage(bytes);
+
+  return (
+    <div className={styles.stage}>
+      <div
+        ref={containerRef}
+        className={styles.canvas}
+        onPointerDown={onPointerDown}
+        onPointerUp={onPointerUp}
+      />
+      {selectedName && <span className={styles.selected}>選択中: {selectedName}</span>}
+      <ViewerToolbar
+        hasAnimation={animations.length > 0}
+        isPlaying={isPlaying}
+        onTogglePlay={togglePlay}
+        onResetView={resetView}
+      />
+    </div>
+  );
+}

--- a/app/(v2)/viewer/ViewerToolbar.module.scss
+++ b/app/(v2)/viewer/ViewerToolbar.module.scss
@@ -1,0 +1,33 @@
+.toolbar {
+  display: flex;
+  gap: var(--space-4);
+  position: absolute;
+  right: var(--space-12);
+  bottom: var(--space-12);
+  z-index: 1;
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: color 0.15s ease, background-color 0.15s ease;
+
+  &:hover {
+    color: var(--color-text);
+    background: var(--color-track);
+  }
+}

--- a/app/(v2)/viewer/ViewerToolbar.tsx
+++ b/app/(v2)/viewer/ViewerToolbar.tsx
@@ -1,0 +1,30 @@
+import { PlayIcon, PauseIcon, RotateIcon } from "../icons";
+import styles from "./ViewerToolbar.module.scss";
+
+interface ViewerToolbarProps {
+  hasAnimation: boolean;
+  isPlaying: boolean;
+  onTogglePlay: () => void;
+  onResetView: () => void;
+}
+
+/** Minimal in-viewer controls: play/pause (when animated) + reset view. */
+export function ViewerToolbar({ hasAnimation, isPlaying, onTogglePlay, onResetView }: ViewerToolbarProps) {
+  return (
+    <div className={styles.toolbar}>
+      {hasAnimation && (
+        <button
+          type="button"
+          className={styles.button}
+          onClick={onTogglePlay}
+          aria-label={isPlaying ? "アニメーションを停止" : "アニメーションを再生"}
+        >
+          {isPlaying ? <PauseIcon size={16} /> : <PlayIcon size={16} />}
+        </button>
+      )}
+      <button type="button" className={styles.button} onClick={onResetView} aria-label="視点をリセット">
+        <RotateIcon size={16} />
+      </button>
+    </div>
+  );
+}

--- a/app/(v2)/viewer/useThreeStage.ts
+++ b/app/(v2)/viewer/useThreeStage.ts
@@ -1,0 +1,309 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment.js";
+import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer.js";
+import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
+import { OutlinePass } from "three/examples/jsm/postprocessing/OutlinePass.js";
+
+const OUTLINE_COLOR = "#2f6bff"; // v2 highlight (electric blue)
+const CLICK_DRAG_THRESHOLD = 4; // px — distinguishes a pick from an orbit drag
+
+/** Free GPU resources held by a model subtree before discarding it. */
+function disposeObject(root: THREE.Object3D) {
+  root.traverse((object) => {
+    const mesh = object as THREE.Mesh;
+    mesh.geometry?.dispose?.();
+    const material = mesh.material;
+    const materials = Array.isArray(material) ? material : material ? [material] : [];
+    materials.forEach((entry) => {
+      Object.values(entry).forEach((value) => {
+        if (value instanceof THREE.Texture) {
+          value.dispose();
+        }
+      });
+      entry.dispose();
+    });
+  });
+}
+
+export interface StageAnimation {
+  name: string;
+  duration: number;
+}
+
+interface StageRefs {
+  renderer: THREE.WebGLRenderer;
+  scene: THREE.Scene;
+  camera: THREE.PerspectiveCamera;
+  controls: OrbitControls;
+  composer: EffectComposer;
+  outlinePass: OutlinePass;
+  mixer: THREE.AnimationMixer | null;
+  model: THREE.Object3D | null;
+  actions: Map<string, THREE.AnimationAction>;
+}
+
+/**
+ * Owns the three.js stage (renderer / scene / camera / controls / composer)
+ * and renders a glb passed as bytes. Plain three.js behind a thin hook — three
+ * objects live in refs (never in React state / the store). Selection uses a
+ * Raycaster + OutlinePass; animation uses an AnimationMixer.
+ */
+export function useThreeStage(bytes: ArrayBuffer | null) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const refs = useRef<StageRefs | null>(null);
+  const clockRef = useRef(new THREE.Clock());
+  const raycasterRef = useRef(new THREE.Raycaster());
+  const pointerDownRef = useRef<{ x: number; y: number } | null>(null);
+
+  const [animations, setAnimations] = useState<StageAnimation[]>([]);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [selectedName, setSelectedName] = useState<string | null>(null);
+
+  // ── Stage lifecycle (mount once) ─────────────────────────────────────────
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const width = container.clientWidth;
+    const height = container.clientHeight;
+
+    const scene = new THREE.Scene();
+    scene.background = null;
+
+    const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
+    camera.position.set(0, 0, 3);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setSize(width, height);
+    renderer.setClearColor(0x000000, 0);
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure = 1;
+    container.appendChild(renderer.domElement);
+
+    const pmrem = new THREE.PMREMGenerator(renderer);
+    scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
+
+    scene.add(new THREE.AmbientLight(0xffffff, 0.5));
+    const directional = new THREE.DirectionalLight(0xffffff, 0.5);
+    directional.position.set(5, 5, 5);
+    scene.add(directional);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+
+    const composer = new EffectComposer(renderer);
+    composer.addPass(new RenderPass(scene, camera));
+    const outlinePass = new OutlinePass(new THREE.Vector2(width, height), scene, camera);
+    outlinePass.visibleEdgeColor.set(OUTLINE_COLOR);
+    outlinePass.hiddenEdgeColor.set(OUTLINE_COLOR);
+    outlinePass.edgeStrength = 4;
+    outlinePass.edgeThickness = 1;
+    composer.addPass(outlinePass);
+
+    refs.current = {
+      renderer,
+      scene,
+      camera,
+      controls,
+      composer,
+      outlinePass,
+      mixer: null,
+      model: null,
+      actions: new Map(),
+    };
+
+    let raf = 0;
+    const renderLoop = () => {
+      raf = requestAnimationFrame(renderLoop);
+      const current = refs.current;
+      if (!current) {
+        return;
+      }
+      const delta = clockRef.current.getDelta();
+      current.mixer?.update(delta);
+      current.controls.update();
+      current.composer.render();
+    };
+    renderLoop();
+
+    const handleResize = () => {
+      const current = refs.current;
+      if (!current || !container.clientWidth) {
+        return;
+      }
+      const nextWidth = container.clientWidth;
+      const nextHeight = container.clientHeight;
+      current.camera.aspect = nextWidth / nextHeight;
+      current.camera.updateProjectionMatrix();
+      current.renderer.setSize(nextWidth, nextHeight);
+      current.composer.setSize(nextWidth, nextHeight);
+      current.outlinePass.setSize(nextWidth, nextHeight);
+    };
+    const resizeObserver = new ResizeObserver(handleResize);
+    resizeObserver.observe(container);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      resizeObserver.disconnect();
+      if (refs.current?.model) {
+        disposeObject(refs.current.model);
+      }
+      pmrem.dispose();
+      controls.dispose();
+      renderer.dispose();
+      renderer.domElement.remove();
+      refs.current = null;
+    };
+  }, []);
+
+  // ── Load / replace the model when bytes change ───────────────────────────
+  useEffect(() => {
+    const current = refs.current;
+    if (!current || !bytes) {
+      return;
+    }
+    let cancelled = false;
+    const loader = new GLTFLoader();
+    loader.parse(
+      bytes.slice(0),
+      "",
+      (gltf) => {
+        if (cancelled || !refs.current) {
+          return;
+        }
+        const stage = refs.current;
+        if (stage.model) {
+          stage.mixer?.stopAllAction();
+          stage.scene.remove(stage.model);
+          disposeObject(stage.model);
+        }
+        stage.outlinePass.selectedObjects = [];
+        setSelectedName(null);
+
+        const model = gltf.scene;
+        stage.scene.add(model);
+        stage.model = model;
+
+        // Fit camera to the model bounds.
+        const box = new THREE.Box3().setFromObject(model);
+        const center = box.getCenter(new THREE.Vector3());
+        const size = box.getSize(new THREE.Vector3());
+        const maxDim = Math.max(size.x, size.y, size.z) || 1;
+        const fov = stage.camera.fov * (Math.PI / 180);
+        const distance = (Math.abs(maxDim / 2 / Math.tan(fov / 2)) || 1) * 1.5;
+        stage.camera.position.set(0, center.y, distance);
+        stage.camera.near = distance / 100;
+        stage.camera.far = distance * 100;
+        stage.camera.updateProjectionMatrix();
+        stage.camera.lookAt(center);
+        stage.controls.target.copy(center);
+        stage.controls.update();
+
+        // Animation.
+        stage.actions.clear();
+        if (gltf.animations.length > 0) {
+          const mixer = new THREE.AnimationMixer(model);
+          stage.mixer = mixer;
+          gltf.animations.forEach((clip) => {
+            stage.actions.set(clip.name, mixer.clipAction(clip));
+          });
+          const first = gltf.animations[0];
+          stage.actions.get(first.name)?.reset().play();
+          setIsPlaying(true);
+          setAnimations(gltf.animations.map((clip) => ({ name: clip.name, duration: clip.duration })));
+        } else {
+          stage.mixer = null;
+          setIsPlaying(false);
+          setAnimations([]);
+        }
+      },
+      () => {
+        // parse error — leave the previous scene untouched
+      }
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [bytes]);
+
+  // ── Picking (click, not drag) ────────────────────────────────────────────
+  const handlePointerDown = useCallback((event: React.PointerEvent) => {
+    pointerDownRef.current = { x: event.clientX, y: event.clientY };
+  }, []);
+
+  const handlePointerUp = useCallback((event: React.PointerEvent) => {
+    const start = pointerDownRef.current;
+    pointerDownRef.current = null;
+    const stage = refs.current;
+    if (!start || !stage || !stage.model) {
+      return;
+    }
+    if (Math.hypot(event.clientX - start.x, event.clientY - start.y) > CLICK_DRAG_THRESHOLD) {
+      return; // it was an orbit drag
+    }
+    const rect = stage.renderer.domElement.getBoundingClientRect();
+    const ndc = new THREE.Vector2(
+      ((event.clientX - rect.left) / rect.width) * 2 - 1,
+      -((event.clientY - rect.top) / rect.height) * 2 + 1
+    );
+    raycasterRef.current.setFromCamera(ndc, stage.camera);
+    const hit = raycasterRef.current.intersectObject(stage.model, true)[0];
+    const mesh = hit?.object as THREE.Mesh | undefined;
+    if (mesh) {
+      stage.outlinePass.selectedObjects = [mesh];
+      setSelectedName(mesh.name || "(no name)");
+    } else {
+      stage.outlinePass.selectedObjects = [];
+      setSelectedName(null);
+    }
+  }, []);
+
+  // ── Controls exposed to the UI ───────────────────────────────────────────
+  const togglePlay = useCallback(() => {
+    const stage = refs.current;
+    if (!stage || !stage.mixer) {
+      return;
+    }
+    setIsPlaying((playing) => {
+      const next = !playing;
+      stage.actions.forEach((action) => {
+        action.paused = !next;
+      });
+      return next;
+    });
+  }, []);
+
+  const resetView = useCallback(() => {
+    const stage = refs.current;
+    if (!stage || !stage.model) {
+      return;
+    }
+    const box = new THREE.Box3().setFromObject(stage.model);
+    const center = box.getCenter(new THREE.Vector3());
+    const size = box.getSize(new THREE.Vector3());
+    const maxDim = Math.max(size.x, size.y, size.z) || 1;
+    const fov = stage.camera.fov * (Math.PI / 180);
+    const distance = (Math.abs(maxDim / 2 / Math.tan(fov / 2)) || 1) * 1.5;
+    stage.camera.position.set(0, center.y, distance);
+    stage.controls.target.copy(center);
+    stage.controls.update();
+  }, []);
+
+  return {
+    containerRef,
+    animations,
+    isPlaying,
+    selectedName,
+    onPointerDown: handlePointerDown,
+    onPointerUp: handlePointerUp,
+    togglePlay,
+    resetView,
+  };
+}

--- a/app/(v2)/viewer/useThreeStage.ts
+++ b/app/(v2)/viewer/useThreeStage.ts
@@ -6,6 +6,7 @@ import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment
 import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer.js";
 import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
 import { OutlinePass } from "three/examples/jsm/postprocessing/OutlinePass.js";
+import { OutputPass } from "three/examples/jsm/postprocessing/OutputPass.js";
 
 const OUTLINE_COLOR = "#2f6bff"; // v2 highlight (electric blue)
 const CLICK_DRAG_THRESHOLD = 4; // px — distinguishes a pick from an orbit drag
@@ -77,17 +78,23 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
     const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
     camera.position.set(0, 0, 3);
 
-    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-    renderer.setSize(width, height);
+    const renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      alpha: true,
+      preserveDrawingBuffer: true,
+      powerPreference: "high-performance",
+    });
     renderer.setClearColor(0x000000, 0);
+    renderer.setSize(width, height);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     renderer.outputColorSpace = THREE.SRGBColorSpace;
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
     renderer.toneMappingExposure = 1;
     container.appendChild(renderer.domElement);
 
+    // Match legacy exactly: sharp RoomEnvironment IBL (no PMREM blur sigma).
     const pmrem = new THREE.PMREMGenerator(renderer);
-    scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
+    scene.environment = pmrem.fromScene(new RoomEnvironment()).texture;
 
     scene.add(new THREE.AmbientLight(0xffffff, 0.5));
     const directional = new THREE.DirectionalLight(0xffffff, 0.5);
@@ -98,6 +105,7 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
     controls.enableDamping = true;
 
     const composer = new EffectComposer(renderer);
+    composer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     composer.addPass(new RenderPass(scene, camera));
     const outlinePass = new OutlinePass(new THREE.Vector2(width, height), scene, camera);
     outlinePass.visibleEdgeColor.set(OUTLINE_COLOR);
@@ -105,6 +113,10 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
     outlinePass.edgeStrength = 4;
     outlinePass.edgeThickness = 1;
     composer.addPass(outlinePass);
+    // OutputPass applies tone mapping + sRGB conversion to the composed frame.
+    // Without it, EffectComposer emits linear color and materials look far too
+    // saturated/dark (matches the legacy viewer's pipeline).
+    composer.addPass(new OutputPass());
 
     refs.current = {
       renderer,


### PR DESCRIPTION
## 概要

新版の 3D 表示層を **素の three.js + カスタムフック**で新規実装 (architecture §2.3)。react-three-fiber は不採用。旧 `ThreeViewer.jsx`(860行)は**参照しない**。

## 変更内容

- **`viewer/useThreeStage.ts`**: renderer / scene / camera / OrbitControls / EffectComposer のライフサイクル、RoomEnvironment(PMREM IBL)、ACESFilmic トーンマップ、レンダリングループ、リサイズ、破棄。three オブジェクトは **ref 保持**(store/state には入れない)。
  - `modelStore.originalBytes` を `GLTFLoader.parse` で描画(**常にバイナリ経由**・ライブシーンは破壊編集しない)。Box3 でカメラフィット、`AnimationMixer` 構築 + 先頭クリップ自動再生。
  - **ピッキング**: pointerup(ドラッグ除外)で Raycaster → ヒットメッシュを `OutlinePass`(v2 ハイライト青 #2f6bff)で強調。
  - モデル差し替え/アンマウント時に geometry/material/texture を dispose。
- **`viewer/Stage.tsx`**: モデル読込時にビューア領域へ canvas を描画。最小 `ViewerToolbar`(再生/停止 + 視点リセット)。
- `page.tsx`: モデル読込時は `Stage` を表示。

> マテリアル調整(roughness/metalness)や文脈タブ(アニメ/マテリアル/メッシュ一覧)は #32、保存/背景/キャプチャは後続 issue。

## 動作確認 (QA / Playwright, test.glb)

- ✅ **3D 表示**: glb 読込で赤キューブ/球/板が描画。
- ✅ **カメラ操作**: キャンバスドラッグで視点回転(OrbitControls)。
- ✅ **アニメ再生/停止**: 先頭クリップ自動再生(pauseボタン表示)。トグルで停止↔再生(アイコン変化 + フレーム差分でキューブの動きを確認)。
- ✅ **メッシュ選択 + アウトライン**: クリックで選択(`選択中: parent` 表示)+ 青アウトライン表示。ドラッグ時は選択しない。
- ✅ 旧コードへの import ゼロ(lint 緑)。`/legacy` 200(回帰なし)、`npm test` 48 件緑、build 成功、コンソールエラーなし。

Closes #31