### PR TITLE
1-2: プレビューモードUI(概要ヘッダー+文脈3タブ)の新規実装

### DIFF
--- a/app/(v2)/components/ModelSummaryCard.module.scss
+++ b/app/(v2)/components/ModelSummaryCard.module.scss
@@ -11,38 +11,26 @@
 
 .title {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: var(--space-4);
   width: 100%;
 }
 
 .fileIcon {
   display: inline-flex;
-  padding-top: 3px;
   color: var(--color-accent);
-}
-
-.fileName {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  flex: 1;
-  min-width: 0;
-  color: var(--color-text);
 }
 
 .name {
   overflow: hidden;
+  flex: 1;
+  min-width: 0;
+  color: var(--color-text);
   font-weight: 600;
   font-size: var(--font-size-16);
   line-height: 20px;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.copyright {
-  font-size: var(--font-size-11);
-  line-height: 14px;
 }
 
 .dataArea {

--- a/app/(v2)/components/ModelSummaryCard.tsx
+++ b/app/(v2)/components/ModelSummaryCard.tsx
@@ -27,12 +27,9 @@ export function ModelSummaryCard() {
         <span className={styles.fileIcon}>
           <FileIcon size={14} />
         </span>
-        <div className={styles.fileName}>
-          <span className={styles.name} title={meta.name}>
-            {meta.name}
-          </span>
-          <span className={styles.copyright}>著作権情報：{meta.copyright ?? "なし"}</span>
-        </div>
+        <span className={styles.name} title={meta.name}>
+          {meta.name}
+        </span>
       </div>
 
       <div className={styles.dataArea}>

--- a/app/(v2)/features/preview/AnimationTab.module.scss
+++ b/app/(v2)/features/preview/AnimationTab.module.scss
@@ -1,0 +1,100 @@
+.list {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  width: 100%;
+  padding: var(--space-4) 0;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.check {
+  flex-shrink: 0;
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid var(--color-border-strong);
+  border-radius: 3px;
+  background: var(--color-surface);
+}
+
+.checkOn {
+  border-color: var(--color-highlight);
+  background: var(--color-highlight);
+}
+
+.name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  color: var(--color-text-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.duration {
+  flex-shrink: 0;
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-text-faint);
+}
+
+.player {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  width: 100%;
+  padding: var(--space-8);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+}
+
+.playButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: var(--color-highlight);
+  color: var(--color-on-accent);
+  cursor: pointer;
+}
+
+.time {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  flex: 1;
+  min-width: 0;
+}
+
+.seek {
+  width: 100%;
+  height: 6px;
+  margin: 0;
+  accent-color: var(--color-highlight);
+  cursor: pointer;
+}
+
+.timeLabel {
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-text-muted);
+}

--- a/app/(v2)/features/preview/AnimationTab.module.scss
+++ b/app/(v2)/features/preview/AnimationTab.module.scss
@@ -21,17 +21,22 @@
 }
 
 .check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex-shrink: 0;
   width: 12px;
   height: 12px;
   border: 1.5px solid var(--color-border-strong);
   border-radius: 3px;
   background: var(--color-surface);
+  color: transparent;
 }
 
 .checkOn {
   border-color: var(--color-highlight);
   background: var(--color-highlight);
+  color: var(--color-on-accent);
 }
 
 .name {
@@ -86,10 +91,48 @@
 }
 
 .seek {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 16px;
+}
+
+.seekTrack {
+  position: relative;
   width: 100%;
   height: 6px;
+  border-radius: var(--radius-sm);
+  background: var(--color-border);
+}
+
+.seekFill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  border-radius: var(--radius-sm);
+  background: var(--color-highlight);
+}
+
+.seekKnob {
+  position: absolute;
+  top: 50%;
+  width: 11.2px;
+  height: 11.2px;
+  transform: translate(-50%, -50%);
+  border: 2px solid var(--color-surface);
+  border-radius: var(--radius-pill);
+  background: var(--color-highlight);
+  pointer-events: none;
+}
+
+.seekInput {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 16px;
   margin: 0;
-  accent-color: var(--color-highlight);
+  opacity: 0;
   cursor: pointer;
 }
 

--- a/app/(v2)/features/preview/AnimationTab.module.scss
+++ b/app/(v2)/features/preview/AnimationTab.module.scss
@@ -27,7 +27,7 @@
   flex-shrink: 0;
   width: 12px;
   height: 12px;
-  border: 1.5px solid var(--color-border-strong);
+  border: 1.5px solid var(--color-text-faint);
   border-radius: 3px;
   background: var(--color-surface);
   color: transparent;

--- a/app/(v2)/features/preview/AnimationTab.tsx
+++ b/app/(v2)/features/preview/AnimationTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { StageController } from "../../viewer/useThreeStage";
-import { FilmIcon, PlayIcon, PauseIcon } from "../../icons";
+import { FilmIcon, PlayIcon, PauseIcon, CheckIcon } from "../../icons";
 import { TabCard } from "./TabCard";
 import styles from "./AnimationTab.module.scss";
 
@@ -15,6 +15,7 @@ function formatClip(duration: number): string {
 export function AnimationTab({ stage }: { stage: StageController }) {
   const { animations, activeClips, isPlaying, currentTime, duration, togglePlay, toggleClip, seek } = stage;
   const clampedTime = duration > 0 ? Math.min(currentTime % duration || 0, duration) : 0;
+  const progress = duration > 0 ? (clampedTime / duration) * 100 : 0;
 
   return (
     <TabCard Icon={FilmIcon} title="アニメーション">
@@ -29,7 +30,9 @@ export function AnimationTab({ stage }: { stage: StageController }) {
                 aria-pressed={checked}
                 onClick={() => toggleClip(clip.name)}
               >
-                <span className={`${styles.check} ${checked ? styles.checkOn : ""}`} aria-hidden="true" />
+                <span className={`${styles.check} ${checked ? styles.checkOn : ""}`} aria-hidden="true">
+                  {checked && <CheckIcon size={9} />}
+                </span>
                 <span className={styles.name}>{clip.name}</span>
                 <span className={styles.duration}>{formatClip(clip.duration)}</span>
               </button>
@@ -48,16 +51,22 @@ export function AnimationTab({ stage }: { stage: StageController }) {
           {isPlaying ? <PauseIcon size={13} /> : <PlayIcon size={13} />}
         </button>
         <div className={styles.time}>
-          <input
-            type="range"
-            className={styles.seek}
-            min={0}
-            max={duration || 0}
-            step={0.01}
-            value={clampedTime}
-            onChange={(event) => seek(Number(event.target.value))}
-            aria-label="再生位置"
-          />
+          <div className={styles.seek}>
+            <div className={styles.seekTrack}>
+              <div className={styles.seekFill} style={{ width: `${progress}%` }} />
+              <span className={styles.seekKnob} style={{ left: `${progress}%` }} />
+            </div>
+            <input
+              type="range"
+              className={styles.seekInput}
+              min={0}
+              max={duration || 0}
+              step={0.01}
+              value={clampedTime}
+              onChange={(event) => seek(Number(event.target.value))}
+              aria-label="再生位置"
+            />
+          </div>
           <span className={styles.timeLabel}>
             {clampedTime.toFixed(1)}s / {duration.toFixed(1)}s
           </span>

--- a/app/(v2)/features/preview/AnimationTab.tsx
+++ b/app/(v2)/features/preview/AnimationTab.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { StageController } from "../../viewer/useThreeStage";
+import { FilmIcon, PlayIcon, PauseIcon } from "../../icons";
+import { TabCard } from "./TabCard";
+import styles from "./AnimationTab.module.scss";
+
+const FPS = 30;
+
+function formatClip(duration: number): string {
+  return `${Math.round(duration * FPS)}f / ${duration.toFixed(1)}s @${FPS}fps`;
+}
+
+/** 動き: animation clip list (toggle which play) + player (play/pause + seek). */
+export function AnimationTab({ stage }: { stage: StageController }) {
+  const { animations, activeClips, isPlaying, currentTime, duration, togglePlay, toggleClip, seek } = stage;
+  const clampedTime = duration > 0 ? Math.min(currentTime % duration || 0, duration) : 0;
+
+  return (
+    <TabCard Icon={FilmIcon} title="アニメーション">
+      <ul className={styles.list}>
+        {animations.map((clip) => {
+          const checked = activeClips.includes(clip.name);
+          return (
+            <li key={clip.name}>
+              <button
+                type="button"
+                className={styles.row}
+                aria-pressed={checked}
+                onClick={() => toggleClip(clip.name)}
+              >
+                <span className={`${styles.check} ${checked ? styles.checkOn : ""}`} aria-hidden="true" />
+                <span className={styles.name}>{clip.name}</span>
+                <span className={styles.duration}>{formatClip(clip.duration)}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className={styles.player}>
+        <button
+          type="button"
+          className={styles.playButton}
+          onClick={togglePlay}
+          aria-label={isPlaying ? "停止" : "再生"}
+        >
+          {isPlaying ? <PauseIcon size={13} /> : <PlayIcon size={13} />}
+        </button>
+        <div className={styles.time}>
+          <input
+            type="range"
+            className={styles.seek}
+            min={0}
+            max={duration || 0}
+            step={0.01}
+            value={clampedTime}
+            onChange={(event) => seek(Number(event.target.value))}
+            aria-label="再生位置"
+          />
+          <span className={styles.timeLabel}>
+            {clampedTime.toFixed(1)}s / {duration.toFixed(1)}s
+          </span>
+        </div>
+      </div>
+    </TabCard>
+  );
+}

--- a/app/(v2)/features/preview/ContextTabs.module.scss
+++ b/app/(v2)/features/preview/ContextTabs.module.scss
@@ -39,6 +39,10 @@
   &:hover:not(.tabActive):not(:disabled) {
     color: var(--color-text);
   }
+
+  svg {
+    flex-shrink: 0;
+  }
 }
 
 .tabActive {

--- a/app/(v2)/features/preview/ContextTabs.module.scss
+++ b/app/(v2)/features/preview/ContextTabs.module.scss
@@ -1,0 +1,47 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.tabs {
+  display: flex;
+  padding: var(--space-4);
+  border-radius: var(--radius-sm);
+  background: var(--color-track);
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  flex: 1;
+  min-width: 0;
+  padding: var(--space-8) var(--space-12);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-muted);
+  font-family: inherit;
+  font-weight: 600;
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color 0.15s ease, background-color 0.15s ease;
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+
+  &:hover:not(.tabActive):not(:disabled) {
+    color: var(--color-text);
+  }
+}
+
+.tabActive {
+  background: var(--color-surface);
+  color: var(--color-accent);
+}

--- a/app/(v2)/features/preview/ContextTabs.tsx
+++ b/app/(v2)/features/preview/ContextTabs.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import type { StageController } from "../../viewer/useThreeStage";
-import { FilmIcon, CircleIcon, LayersIcon, type IconProps } from "../../icons";
+import { FilmIcon, SphereIcon, LayersIcon, type IconProps } from "../../icons";
 import { AnimationTab } from "./AnimationTab";
 import { MaterialTab } from "./MaterialTab";
 import { MeshTab } from "./MeshTab";
@@ -12,7 +12,7 @@ type TabKey = "animation" | "material" | "mesh";
 
 const TABS: { key: TabKey; label: string; Icon: (props: IconProps) => React.ReactElement }[] = [
   { key: "animation", label: "アニメーション", Icon: FilmIcon },
-  { key: "material", label: "マテリアル", Icon: CircleIcon },
+  { key: "material", label: "マテリアル", Icon: SphereIcon },
   { key: "mesh", label: "メッシュ", Icon: LayersIcon },
 ];
 
@@ -49,7 +49,7 @@ export function ContextTabs({ stage }: { stage: StageController }) {
               className={`${styles.tab} ${isActive ? styles.tabActive : ""}`}
               onClick={() => setActive(key)}
             >
-              <Icon size={14} />
+              <Icon size={16} />
               {label}
             </button>
           );

--- a/app/(v2)/features/preview/ContextTabs.tsx
+++ b/app/(v2)/features/preview/ContextTabs.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { StageController } from "../../viewer/useThreeStage";
+import { FilmIcon, CircleIcon, LayersIcon, type IconProps } from "../../icons";
+import { AnimationTab } from "./AnimationTab";
+import { MaterialTab } from "./MaterialTab";
+import { MeshTab } from "./MeshTab";
+import styles from "./ContextTabs.module.scss";
+
+type TabKey = "animation" | "material" | "mesh";
+
+const TABS: { key: TabKey; label: string; Icon: (props: IconProps) => React.ReactElement }[] = [
+  { key: "animation", label: "アニメーション", Icon: FilmIcon },
+  { key: "material", label: "マテリアル", Icon: CircleIcon },
+  { key: "mesh", label: "メッシュ", Icon: LayersIcon },
+];
+
+/** Contextual preview tabs (Figma preview screen): animation / material / mesh.
+ *  Empty tabs are disabled (F-13). */
+export function ContextTabs({ stage }: { stage: StageController }) {
+  const counts: Record<TabKey, number> = {
+    animation: stage.animations.length,
+    material: stage.materials.length,
+    mesh: stage.meshTree ? stage.meshTree.children.length : 0,
+  };
+
+  const firstEnabled = useMemo(
+    () => TABS.find((tab) => counts[tab.key] > 0)?.key ?? "mesh",
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [counts.animation, counts.material, counts.mesh]
+  );
+  const [active, setActive] = useState<TabKey | null>(null);
+  const activeKey = active && counts[active] > 0 ? active : firstEnabled;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.tabs} role="tablist" aria-label="プレビュー情報">
+        {TABS.map(({ key, label, Icon }) => {
+          const disabled = counts[key] === 0;
+          const isActive = activeKey === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              disabled={disabled}
+              className={`${styles.tab} ${isActive ? styles.tabActive : ""}`}
+              onClick={() => setActive(key)}
+            >
+              <Icon size={14} />
+              {label}
+            </button>
+          );
+        })}
+      </div>
+      {activeKey === "animation" && <AnimationTab stage={stage} />}
+      {activeKey === "material" && <MaterialTab stage={stage} />}
+      {activeKey === "mesh" && <MeshTab stage={stage} />}
+    </div>
+  );
+}

--- a/app/(v2)/features/preview/MaterialTab.module.scss
+++ b/app/(v2)/features/preview/MaterialTab.module.scss
@@ -110,6 +110,12 @@
   color: var(--color-text-muted);
 }
 
+.textureSize {
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-text-muted);
+}
+
 .param {
   display: flex;
   flex-direction: column;
@@ -158,11 +164,11 @@
 }
 
 .cta {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: var(--space-2);
-  width: 100%;
-  padding: var(--space-12) var(--space-8);
+  align-self: flex-end;
+  gap: var(--space-8);
+  padding: var(--space-12) var(--space-18);
   border: none;
   border-radius: var(--radius-sm);
   background: var(--color-accent);
@@ -177,10 +183,7 @@
 }
 
 .ctaLabel {
-  flex: 1;
-  min-width: 0;
   font-weight: 600;
   font-size: var(--font-size-14);
   line-height: 18px;
-  text-align: left;
 }

--- a/app/(v2)/features/preview/MaterialTab.module.scss
+++ b/app/(v2)/features/preview/MaterialTab.module.scss
@@ -43,20 +43,13 @@
   color: var(--color-text-muted);
 }
 
-.slider {
+.param {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
-
-  input {
-    width: 100%;
-    margin: 0;
-    accent-color: var(--color-highlight);
-    cursor: pointer;
-  }
+  gap: var(--space-8);
 }
 
-.sliderHead {
+.paramHead {
   display: flex;
   justify-content: space-between;
   font-size: var(--font-size-11);
@@ -65,6 +58,34 @@
 }
 
 .value {
-  font-variant-numeric: tabular-nums;
   color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.bar {
+  position: relative;
+  width: 100%;
+  height: 11.2px;
+}
+
+.bar::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 2px;
+  transform: translateY(-50%);
+  background: var(--color-border-strong);
+}
+
+.knob {
+  position: absolute;
+  top: 50%;
+  width: 11.2px;
+  height: 11.2px;
+  transform: translate(-50%, -50%);
+  border: 2px solid var(--color-surface);
+  border-radius: var(--radius-pill);
+  background: var(--color-highlight);
 }

--- a/app/(v2)/features/preview/MaterialTab.module.scss
+++ b/app/(v2)/features/preview/MaterialTab.module.scss
@@ -1,57 +1,85 @@
 .list {
   display: flex;
   flex-direction: column;
-  gap: var(--space-12);
+  gap: var(--space-2);
   width: 100%;
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
-.material {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-8);
-  padding-bottom: var(--space-12);
-  border-bottom: 1px solid var(--color-border);
-
-  &:last-child {
-    padding-bottom: 0;
-    border-bottom: none;
-  }
-}
-
-.head {
+.row {
   display: flex;
   align-items: center;
   gap: var(--space-4);
+  width: 100%;
+  padding: var(--space-4) var(--space-8);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--color-highlight-soft);
+  }
+}
+
+.rowActive {
+  background: var(--color-highlight-soft);
 }
 
 .headIcon {
   display: inline-flex;
+  flex-shrink: 0;
   color: var(--color-text-muted);
 }
 
 .name {
+  overflow: hidden;
   font-weight: 600;
   font-size: var(--font-size-14);
   line-height: 18px;
   color: var(--color-text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.maps {
+.details {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+  padding: var(--space-8) var(--space-8) var(--space-12);
+}
+
+.textures {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-4);
+  gap: var(--space-8);
 }
 
-.mapChip {
-  padding: 2px var(--space-8);
+.texture {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0;
+}
+
+.thumb {
+  width: 56px;
+  height: 56px;
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   background: var(--color-bg);
-  font-size: var(--font-size-11);
-  line-height: 14px;
-  color: var(--color-text-muted);
+  object-fit: cover;
+}
+
+.textureLabel {
+  font-size: var(--font-size-9);
+  line-height: 12px;
+  color: var(--color-text-faint);
+  text-align: center;
 }
 
 .param {

--- a/app/(v2)/features/preview/MaterialTab.module.scss
+++ b/app/(v2)/features/preview/MaterialTab.module.scss
@@ -1,0 +1,70 @@
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.material {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+  padding-bottom: var(--space-12);
+  border-bottom: 1px solid var(--color-border);
+
+  &:last-child {
+    padding-bottom: 0;
+    border-bottom: none;
+  }
+}
+
+.name {
+  font-weight: 600;
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  color: var(--color-text);
+}
+
+.maps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+}
+
+.mapChip {
+  padding: 2px var(--space-8);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-text-muted);
+}
+
+.slider {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+
+  input {
+    width: 100%;
+    margin: 0;
+    accent-color: var(--color-highlight);
+    cursor: pointer;
+  }
+}
+
+.sliderHead {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-text-muted);
+}
+
+.value {
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text);
+}

--- a/app/(v2)/features/preview/MaterialTab.module.scss
+++ b/app/(v2)/features/preview/MaterialTab.module.scss
@@ -38,7 +38,6 @@
 
 .name {
   overflow: hidden;
-  font-weight: 600;
   font-size: var(--font-size-14);
   line-height: 18px;
   color: var(--color-text);
@@ -53,33 +52,62 @@
   padding: var(--space-8) var(--space-8) var(--space-12);
 }
 
-.textures {
+.textureBlock {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: var(--space-8);
+}
+
+.textureHeading {
+  font-weight: 600;
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-text);
 }
 
 .texture {
   display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  margin: 0;
+  align-items: center;
+  gap: var(--space-8);
 }
 
 .thumb {
-  width: 56px;
-  height: 56px;
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   background: var(--color-bg);
   object-fit: cover;
 }
 
-.textureLabel {
-  font-size: var(--font-size-9);
-  line-height: 12px;
+.textureMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.textureType {
+  font-size: var(--font-size-11);
+  line-height: 14px;
   color: var(--color-text-faint);
-  text-align: center;
+}
+
+.textureName {
+  overflow: hidden;
+  font-weight: 600;
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  color: var(--color-text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.textureDim {
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-text-muted);
 }
 
 .param {
@@ -127,4 +155,32 @@
   border: 2px solid var(--color-surface);
   border-radius: var(--radius-pill);
   background: var(--color-text-faint);
+}
+
+.cta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-12) var(--space-8);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  font-family: inherit;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background: var(--color-accent-strong);
+  }
+}
+
+.ctaLabel {
+  flex: 1;
+  min-width: 0;
+  font-weight: 600;
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  text-align: left;
 }

--- a/app/(v2)/features/preview/MaterialTab.module.scss
+++ b/app/(v2)/features/preview/MaterialTab.module.scss
@@ -73,8 +73,8 @@
 
 .thumb {
   flex-shrink: 0;
-  width: 48px;
-  height: 48px;
+  width: 72px;
+  height: 72px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   background: var(--color-bg);
@@ -85,6 +85,7 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+  flex: 1;
   min-width: 0;
 }
 

--- a/app/(v2)/features/preview/MaterialTab.module.scss
+++ b/app/(v2)/features/preview/MaterialTab.module.scss
@@ -21,6 +21,17 @@
   }
 }
 
+.head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.headIcon {
+  display: inline-flex;
+  color: var(--color-text-muted);
+}
+
 .name {
   font-weight: 600;
   font-size: var(--font-size-14);
@@ -76,7 +87,7 @@
   top: 50%;
   height: 2px;
   transform: translateY(-50%);
-  background: var(--color-border-strong);
+  background: var(--color-border-2);
 }
 
 .knob {
@@ -87,5 +98,5 @@
   transform: translate(-50%, -50%);
   border: 2px solid var(--color-surface);
   border-radius: var(--radius-pill);
-  background: var(--color-highlight);
+  background: var(--color-text-faint);
 }

--- a/app/(v2)/features/preview/MaterialTab.tsx
+++ b/app/(v2)/features/preview/MaterialTab.tsx
@@ -1,18 +1,10 @@
 "use client";
 
+import { useState } from "react";
 import type { StageController } from "../../viewer/useThreeStage";
 import { SphereIcon } from "../../icons";
 import { TabCard } from "./TabCard";
 import styles from "./MaterialTab.module.scss";
-
-const MAP_LABELS: Record<string, string> = {
-  map: "baseColor",
-  normalMap: "normal",
-  roughnessMap: "roughness",
-  metalnessMap: "metalness",
-  emissiveMap: "emissive",
-  aoMap: "ao",
-};
 
 /** Read-only value bar (Figma Slider): a thin line with a knob at `value` (0–1). */
 function ValueBar({ label, value }: { label: string; value: number }) {
@@ -29,32 +21,51 @@ function ValueBar({ label, value }: { label: string; value: number }) {
   );
 }
 
-/** 見た目: materials with read-only roughness / metalness value bars. */
+/**
+ * 見た目: material list. Selecting a material reveals its textures and read-only
+ * roughness / metalness bars (hidden by default).
+ */
 export function MaterialTab({ stage }: { stage: StageController }) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
   return (
     <TabCard Icon={SphereIcon} title="マテリアル">
       <ul className={styles.list}>
-        {stage.materials.map((material) => (
-          <li key={material.id} className={styles.material}>
-            <span className={styles.head}>
-              <span className={styles.headIcon}>
-                <SphereIcon size={14} />
-              </span>
-              <span className={styles.name}>{material.name}</span>
-            </span>
-            {material.maps.length > 0 && (
-              <div className={styles.maps}>
-                {material.maps.map((map) => (
-                  <span key={map} className={styles.mapChip}>
-                    {MAP_LABELS[map] ?? map}
-                  </span>
-                ))}
-              </div>
-            )}
-            <ValueBar label="粗さ (Roughness)" value={material.roughness} />
-            <ValueBar label="金属感 (Metalness)" value={material.metalness} />
-          </li>
-        ))}
+        {stage.materials.map((material) => {
+          const open = selectedId === material.id;
+          return (
+            <li key={material.id}>
+              <button
+                type="button"
+                className={`${styles.row} ${open ? styles.rowActive : ""}`}
+                aria-expanded={open}
+                onClick={() => setSelectedId(open ? null : material.id)}
+              >
+                <span className={styles.headIcon}>
+                  <SphereIcon size={14} />
+                </span>
+                <span className={styles.name}>{material.name}</span>
+              </button>
+              {open && (
+                <div className={styles.details}>
+                  {material.textures.length > 0 && (
+                    <div className={styles.textures}>
+                      {material.textures.map((texture) => (
+                        <figure key={texture.type} className={styles.texture}>
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
+                          <img className={styles.thumb} src={texture.url} alt={texture.type} />
+                          <figcaption className={styles.textureLabel}>{texture.type}</figcaption>
+                        </figure>
+                      ))}
+                    </div>
+                  )}
+                  <ValueBar label="粗さ (Roughness)" value={material.roughness} />
+                  <ValueBar label="金属感 (Metalness)" value={material.metalness} />
+                </div>
+              )}
+            </li>
+          );
+        })}
       </ul>
     </TabCard>
   );

--- a/app/(v2)/features/preview/MaterialTab.tsx
+++ b/app/(v2)/features/preview/MaterialTab.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import type { StageController } from "../../viewer/useThreeStage";
+import { CircleIcon } from "../../icons";
+import { TabCard } from "./TabCard";
+import styles from "./MaterialTab.module.scss";
+
+const MAP_LABELS: Record<string, string> = {
+  map: "baseColor",
+  normalMap: "normal",
+  roughnessMap: "roughness",
+  metalnessMap: "metalness",
+  emissiveMap: "emissive",
+  aoMap: "ao",
+};
+
+/** 見た目: materials with live (preview-only) roughness / metalness sliders. */
+export function MaterialTab({ stage }: { stage: StageController }) {
+  const { materials, setMaterialParam } = stage;
+
+  return (
+    <TabCard Icon={CircleIcon} title="マテリアル">
+      <ul className={styles.list}>
+        {materials.map((material) => (
+          <li key={material.id} className={styles.material}>
+            <span className={styles.name}>{material.name}</span>
+            {material.maps.length > 0 && (
+              <div className={styles.maps}>
+                {material.maps.map((map) => (
+                  <span key={map} className={styles.mapChip}>
+                    {MAP_LABELS[map] ?? map}
+                  </span>
+                ))}
+              </div>
+            )}
+            <label className={styles.slider}>
+              <span className={styles.sliderHead}>
+                <span>粗さ (Roughness)</span>
+                <span className={styles.value}>{material.roughness.toFixed(2)}</span>
+              </span>
+              <input
+                type="range"
+                min={0}
+                max={1}
+                step={0.01}
+                value={material.roughness}
+                onChange={(event) => setMaterialParam(material.id, "roughness", Number(event.target.value))}
+              />
+            </label>
+            <label className={styles.slider}>
+              <span className={styles.sliderHead}>
+                <span>金属感 (Metalness)</span>
+                <span className={styles.value}>{material.metalness.toFixed(2)}</span>
+              </span>
+              <input
+                type="range"
+                min={0}
+                max={1}
+                step={0.01}
+                value={material.metalness}
+                onChange={(event) => setMaterialParam(material.id, "metalness", Number(event.target.value))}
+              />
+            </label>
+          </li>
+        ))}
+      </ul>
+    </TabCard>
+  );
+}

--- a/app/(v2)/features/preview/MaterialTab.tsx
+++ b/app/(v2)/features/preview/MaterialTab.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import type { StageController } from "../../viewer/useThreeStage";
 import { useUiStore } from "../../store/uiStore";
+import { formatFileSize } from "../../lib/formatFileSize";
 import { SphereIcon, ZapIcon, ArrowRightIcon } from "../../icons";
 import { TabCard } from "./TabCard";
 import styles from "./MaterialTab.module.scss";
@@ -75,6 +76,9 @@ export function MaterialTab({ stage }: { stage: StageController }) {
                               <span className={styles.textureDim}>
                                 {texture.width} × {texture.height} px
                               </span>
+                            )}
+                            {texture.byteLength > 0 && (
+                              <span className={styles.textureSize}>{formatFileSize(texture.byteLength)}</span>
                             )}
                           </div>
                         </div>

--- a/app/(v2)/features/preview/MaterialTab.tsx
+++ b/app/(v2)/features/preview/MaterialTab.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from "react";
 import type { StageController } from "../../viewer/useThreeStage";
-import { SphereIcon } from "../../icons";
+import { useUiStore } from "../../store/uiStore";
+import { SphereIcon, ZapIcon, ArrowRightIcon } from "../../icons";
 import { TabCard } from "./TabCard";
 import styles from "./MaterialTab.module.scss";
 
@@ -23,10 +24,11 @@ function ValueBar({ label, value }: { label: string; value: number }) {
 
 /**
  * 見た目: material list. Selecting a material reveals its textures and read-only
- * roughness / metalness bars (hidden by default).
+ * roughness / metalness bars. Multiple materials can stay open at once.
  */
 export function MaterialTab({ stage }: { stage: StageController }) {
   const [openIds, setOpenIds] = useState<Set<string>>(new Set());
+  const setMode = useUiStore((state) => state.setMode);
 
   const toggle = (id: string) =>
     setOpenIds((prev) => {
@@ -60,13 +62,22 @@ export function MaterialTab({ stage }: { stage: StageController }) {
               {open && (
                 <div className={styles.details}>
                   {material.textures.length > 0 && (
-                    <div className={styles.textures}>
-                      {material.textures.map((texture) => (
-                        <figure key={texture.type} className={styles.texture}>
+                    <div className={styles.textureBlock}>
+                      <span className={styles.textureHeading}>テクスチャ</span>
+                      {material.textures.map((texture, index) => (
+                        <div key={`${texture.type}-${index}`} className={styles.texture}>
                           {/* eslint-disable-next-line @next/next/no-img-element */}
                           <img className={styles.thumb} src={texture.url} alt={texture.type} />
-                          <figcaption className={styles.textureLabel}>{texture.type}</figcaption>
-                        </figure>
+                          <div className={styles.textureMeta}>
+                            <span className={styles.textureType}>{texture.type}</span>
+                            {texture.name && <span className={styles.textureName}>{texture.name}</span>}
+                            {texture.width > 0 && (
+                              <span className={styles.textureDim}>
+                                {texture.width} × {texture.height} px
+                              </span>
+                            )}
+                          </div>
+                        </div>
                       ))}
                     </div>
                   )}
@@ -78,6 +89,12 @@ export function MaterialTab({ stage }: { stage: StageController }) {
           );
         })}
       </ul>
+
+      <button type="button" className={styles.cta} onClick={() => setMode("optimize")}>
+        <ZapIcon size={16} />
+        <span className={styles.ctaLabel}>マテリアルの最適化をする</span>
+        <ArrowRightIcon size={16} />
+      </button>
     </TabCard>
   );
 }

--- a/app/(v2)/features/preview/MaterialTab.tsx
+++ b/app/(v2)/features/preview/MaterialTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { StageController } from "../../viewer/useThreeStage";
-import { CircleIcon } from "../../icons";
+import { SphereIcon } from "../../icons";
 import { TabCard } from "./TabCard";
 import styles from "./MaterialTab.module.scss";
 
@@ -14,14 +14,27 @@ const MAP_LABELS: Record<string, string> = {
   aoMap: "ao",
 };
 
-/** 見た目: materials with live (preview-only) roughness / metalness sliders. */
-export function MaterialTab({ stage }: { stage: StageController }) {
-  const { materials, setMaterialParam } = stage;
-
+/** Read-only value bar (Figma Slider): a thin line with a knob at `value` (0–1). */
+function ValueBar({ label, value }: { label: string; value: number }) {
   return (
-    <TabCard Icon={CircleIcon} title="マテリアル">
+    <div className={styles.param}>
+      <span className={styles.paramHead}>
+        <span>{label}</span>
+        <span className={styles.value}>{value.toFixed(2)}</span>
+      </span>
+      <div className={styles.bar}>
+        <span className={styles.knob} style={{ left: `${value * 100}%` }} />
+      </div>
+    </div>
+  );
+}
+
+/** 見た目: materials with read-only roughness / metalness value bars. */
+export function MaterialTab({ stage }: { stage: StageController }) {
+  return (
+    <TabCard Icon={SphereIcon} title="マテリアル">
       <ul className={styles.list}>
-        {materials.map((material) => (
+        {stage.materials.map((material) => (
           <li key={material.id} className={styles.material}>
             <span className={styles.name}>{material.name}</span>
             {material.maps.length > 0 && (
@@ -33,34 +46,8 @@ export function MaterialTab({ stage }: { stage: StageController }) {
                 ))}
               </div>
             )}
-            <label className={styles.slider}>
-              <span className={styles.sliderHead}>
-                <span>粗さ (Roughness)</span>
-                <span className={styles.value}>{material.roughness.toFixed(2)}</span>
-              </span>
-              <input
-                type="range"
-                min={0}
-                max={1}
-                step={0.01}
-                value={material.roughness}
-                onChange={(event) => setMaterialParam(material.id, "roughness", Number(event.target.value))}
-              />
-            </label>
-            <label className={styles.slider}>
-              <span className={styles.sliderHead}>
-                <span>金属感 (Metalness)</span>
-                <span className={styles.value}>{material.metalness.toFixed(2)}</span>
-              </span>
-              <input
-                type="range"
-                min={0}
-                max={1}
-                step={0.01}
-                value={material.metalness}
-                onChange={(event) => setMaterialParam(material.id, "metalness", Number(event.target.value))}
-              />
-            </label>
+            <ValueBar label="粗さ (Roughness)" value={material.roughness} />
+            <ValueBar label="金属感 (Metalness)" value={material.metalness} />
           </li>
         ))}
       </ul>

--- a/app/(v2)/features/preview/MaterialTab.tsx
+++ b/app/(v2)/features/preview/MaterialTab.tsx
@@ -36,7 +36,12 @@ export function MaterialTab({ stage }: { stage: StageController }) {
       <ul className={styles.list}>
         {stage.materials.map((material) => (
           <li key={material.id} className={styles.material}>
-            <span className={styles.name}>{material.name}</span>
+            <span className={styles.head}>
+              <span className={styles.headIcon}>
+                <SphereIcon size={14} />
+              </span>
+              <span className={styles.name}>{material.name}</span>
+            </span>
             {material.maps.length > 0 && (
               <div className={styles.maps}>
                 {material.maps.map((map) => (

--- a/app/(v2)/features/preview/MaterialTab.tsx
+++ b/app/(v2)/features/preview/MaterialTab.tsx
@@ -26,20 +26,31 @@ function ValueBar({ label, value }: { label: string; value: number }) {
  * roughness / metalness bars (hidden by default).
  */
 export function MaterialTab({ stage }: { stage: StageController }) {
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [openIds, setOpenIds] = useState<Set<string>>(new Set());
+
+  const toggle = (id: string) =>
+    setOpenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
 
   return (
     <TabCard Icon={SphereIcon} title="マテリアル">
       <ul className={styles.list}>
         {stage.materials.map((material) => {
-          const open = selectedId === material.id;
+          const open = openIds.has(material.id);
           return (
             <li key={material.id}>
               <button
                 type="button"
                 className={`${styles.row} ${open ? styles.rowActive : ""}`}
                 aria-expanded={open}
-                onClick={() => setSelectedId(open ? null : material.id)}
+                onClick={() => toggle(material.id)}
               >
                 <span className={styles.headIcon}>
                   <SphereIcon size={14} />

--- a/app/(v2)/features/preview/MeshTab.module.scss
+++ b/app/(v2)/features/preview/MeshTab.module.scss
@@ -38,7 +38,8 @@
 
 .treeWrap {
   width: 100%;
-  overflow-x: auto;
+  max-height: 40vh;
+  overflow: auto;
 }
 
 .tree {

--- a/app/(v2)/features/preview/MeshTab.module.scss
+++ b/app/(v2)/features/preview/MeshTab.module.scss
@@ -111,11 +111,11 @@
 }
 
 .cta {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: var(--space-2);
-  width: 100%;
-  padding: var(--space-12) var(--space-8);
+  align-self: flex-end;
+  gap: var(--space-8);
+  padding: var(--space-12) var(--space-18);
   border: none;
   border-radius: var(--radius-sm);
   background: var(--color-accent);
@@ -130,10 +130,7 @@
 }
 
 .ctaLabel {
-  flex: 1;
-  min-width: 0;
   font-weight: 600;
   font-size: var(--font-size-14);
   line-height: 18px;
-  text-align: left;
 }

--- a/app/(v2)/features/preview/MeshTab.module.scss
+++ b/app/(v2)/features/preview/MeshTab.module.scss
@@ -1,11 +1,48 @@
-.tree {
+.pickToggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
   width: 100%;
-  margin: 0;
   padding: 0;
-  list-style: none;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
 }
 
-.group {
+.check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid var(--color-text-faint);
+  border-radius: 3px;
+  background: var(--color-surface);
+  color: transparent;
+}
+
+.checkOn {
+  border-color: var(--color-highlight);
+  background: var(--color-highlight);
+  color: var(--color-on-accent);
+}
+
+.pickLabel {
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-text-muted);
+}
+
+.treeWrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.tree {
+  min-width: max-content;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -15,11 +52,12 @@
   display: flex;
   align-items: center;
   gap: var(--space-4);
+  min-width: 100%;
   padding: var(--space-2) var(--space-8);
   border-radius: var(--radius-sm);
 
   &:hover {
-    background: var(--color-bg);
+    background: var(--color-highlight-soft);
   }
 }
 
@@ -52,13 +90,13 @@
   align-items: center;
   gap: var(--space-4);
   flex: 1;
-  min-width: 0;
   padding: var(--space-4) 0;
   border: none;
   background: transparent;
   color: var(--color-text-muted);
   font-family: inherit;
   text-align: left;
+  white-space: nowrap;
   cursor: pointer;
 
   svg {
@@ -67,9 +105,34 @@
 }
 
 .name {
-  overflow: hidden;
   font-size: var(--font-size-14);
   line-height: 18px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+}
+
+.cta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-12) var(--space-8);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  font-family: inherit;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background: var(--color-accent-strong);
+  }
+}
+
+.ctaLabel {
+  flex: 1;
+  min-width: 0;
+  font-weight: 600;
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  text-align: left;
 }

--- a/app/(v2)/features/preview/MeshTab.module.scss
+++ b/app/(v2)/features/preview/MeshTab.module.scss
@@ -15,6 +15,7 @@
   display: flex;
   align-items: center;
   gap: var(--space-4);
+  padding: var(--space-2) var(--space-8);
   border-radius: var(--radius-sm);
 
   &:hover {
@@ -23,7 +24,7 @@
 }
 
 .rowSelected {
-  background: var(--color-bg);
+  background: var(--color-highlight-soft);
 }
 
 .toggle {
@@ -31,50 +32,44 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   padding: 0;
   border: none;
   background: transparent;
   color: var(--color-text-faint);
-  font-size: 10px;
+  font-size: 9px;
   cursor: pointer;
 }
 
 .toggleSpacer {
   flex-shrink: 0;
-  width: 16px;
+  width: 14px;
 }
 
 .label {
   display: flex;
   align-items: center;
-  gap: var(--space-8);
+  gap: var(--space-4);
   flex: 1;
   min-width: 0;
   padding: var(--space-4) 0;
   border: none;
   background: transparent;
+  color: var(--color-text-muted);
   font-family: inherit;
   text-align: left;
   cursor: pointer;
+
+  svg {
+    flex-shrink: 0;
+  }
 }
 
 .name {
   overflow: hidden;
   font-size: var(--font-size-14);
   line-height: 18px;
-  color: var(--color-text);
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.badge {
-  flex-shrink: 0;
-  padding: 0 var(--space-4);
-  border-radius: var(--radius-sm);
-  background: var(--color-track);
-  font-size: var(--font-size-9);
-  line-height: 14px;
-  color: var(--color-text-faint);
 }

--- a/app/(v2)/features/preview/MeshTab.module.scss
+++ b/app/(v2)/features/preview/MeshTab.module.scss
@@ -1,0 +1,80 @@
+.tree {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.group {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  border-radius: var(--radius-sm);
+
+  &:hover {
+    background: var(--color-bg);
+  }
+}
+
+.rowSelected {
+  background: var(--color-bg);
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--color-text-faint);
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.toggleSpacer {
+  flex-shrink: 0;
+  width: 16px;
+}
+
+.label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  flex: 1;
+  min-width: 0;
+  padding: var(--space-4) 0;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.name {
+  overflow: hidden;
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  color: var(--color-text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.badge {
+  flex-shrink: 0;
+  padding: 0 var(--space-4);
+  border-radius: var(--radius-sm);
+  background: var(--color-track);
+  font-size: var(--font-size-9);
+  line-height: 14px;
+  color: var(--color-text-faint);
+}

--- a/app/(v2)/features/preview/MeshTab.tsx
+++ b/app/(v2)/features/preview/MeshTab.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import type { StageController, MeshNode } from "../../viewer/useThreeStage";
+import { LayersIcon } from "../../icons";
+import { TabCard } from "./TabCard";
+import styles from "./MeshTab.module.scss";
+
+/** モデル: mesh structure tree, click-synced with the viewer selection. */
+export function MeshTab({ stage }: { stage: StageController }) {
+  const { meshTree, selectedUuid, selectMesh } = stage;
+
+  return (
+    <TabCard Icon={LayersIcon} title="メッシュ">
+      <ul className={styles.tree} role="tree">
+        {meshTree && (
+          <TreeNode node={meshTree} depth={0} selectedUuid={selectedUuid} onSelect={selectMesh} />
+        )}
+      </ul>
+    </TabCard>
+  );
+}
+
+interface TreeNodeProps {
+  node: MeshNode;
+  depth: number;
+  selectedUuid: string | null;
+  onSelect: (uuid: string | null) => void;
+}
+
+function TreeNode({ node, depth, selectedUuid, onSelect }: TreeNodeProps) {
+  const [open, setOpen] = useState(true);
+  const hasChildren = node.children.length > 0;
+  const isSelected = selectedUuid === node.uuid;
+
+  return (
+    <li role="treeitem" aria-selected={isSelected} aria-expanded={hasChildren ? open : undefined}>
+      <div
+        className={`${styles.row} ${isSelected ? styles.rowSelected : ""}`}
+        style={{ paddingLeft: `calc(${depth} * var(--space-12))` }}
+      >
+        {hasChildren ? (
+          <button
+            type="button"
+            className={styles.toggle}
+            onClick={() => setOpen((value) => !value)}
+            aria-label={open ? "折りたたむ" : "展開する"}
+          >
+            {open ? "▾" : "▸"}
+          </button>
+        ) : (
+          <span className={styles.toggleSpacer} />
+        )}
+        <button
+          type="button"
+          className={styles.label}
+          onClick={() => onSelect(isSelected ? null : node.uuid)}
+        >
+          <span className={styles.name}>{node.name}</span>
+          {node.isMesh && <span className={styles.badge}>mesh</span>}
+        </button>
+      </div>
+      {hasChildren && open && (
+        <ul role="group" className={styles.group}>
+          {node.children.map((child) => (
+            <TreeNode
+              key={child.uuid}
+              node={child}
+              depth={depth + 1}
+              selectedUuid={selectedUuid}
+              onSelect={onSelect}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}

--- a/app/(v2)/features/preview/MeshTab.tsx
+++ b/app/(v2)/features/preview/MeshTab.tsx
@@ -2,78 +2,105 @@
 
 import { useState } from "react";
 import type { StageController, MeshNode } from "../../viewer/useThreeStage";
-import { LayersIcon, CubeIcon } from "../../icons";
+import { useUiStore } from "../../store/uiStore";
+import { LayersIcon, CubeIcon, CheckIcon, ZapIcon, ArrowRightIcon } from "../../icons";
 import { TabCard } from "./TabCard";
 import styles from "./MeshTab.module.scss";
 
-/** モデル: mesh structure tree, click-synced with the viewer selection. */
-export function MeshTab({ stage }: { stage: StageController }) {
-  const { meshTree, selectedUuid, selectMesh } = stage;
-
-  return (
-    <TabCard Icon={LayersIcon} title="メッシュ">
-      <ul className={styles.tree} role="tree">
-        {meshTree && (
-          <TreeNode node={meshTree} depth={0} selectedUuid={selectedUuid} onSelect={selectMesh} />
-        )}
-      </ul>
-    </TabCard>
-  );
-}
-
-interface TreeNodeProps {
+interface FlatRow {
   node: MeshNode;
   depth: number;
-  selectedUuid: string | null;
-  onSelect: (uuid: string | null) => void;
 }
 
-function TreeNode({ node, depth, selectedUuid, onSelect }: TreeNodeProps) {
-  const [open, setOpen] = useState(true);
-  const hasChildren = node.children.length > 0;
-  const isSelected = selectedUuid === node.uuid;
-  const NodeIcon = node.isMesh ? CubeIcon : LayersIcon;
+/** Flatten the tree into visible rows, honoring collapsed nodes. */
+function flatten(node: MeshNode, collapsed: Set<string>, depth = 0, acc: FlatRow[] = []): FlatRow[] {
+  acc.push({ node, depth });
+  if (node.children.length > 0 && !collapsed.has(node.uuid)) {
+    node.children.forEach((child) => flatten(child, collapsed, depth + 1, acc));
+  }
+  return acc;
+}
+
+/** モデル: mesh structure tree, click-synced with the viewer selection. */
+export function MeshTab({ stage }: { stage: StageController }) {
+  const { meshTree, selectedUuid, selectMesh, pickingEnabled, setPickingEnabled } = stage;
+  const setMode = useUiStore((state) => state.setMode);
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+
+  const rows = meshTree ? flatten(meshTree, collapsed) : [];
+
+  const toggleCollapse = (uuid: string) =>
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(uuid)) {
+        next.delete(uuid);
+      } else {
+        next.add(uuid);
+      }
+      return next;
+    });
 
   return (
-    <li role="treeitem" aria-selected={isSelected} aria-expanded={hasChildren ? open : undefined}>
-      <div
-        className={`${styles.row} ${isSelected ? styles.rowSelected : ""}`}
-        style={{ paddingLeft: `calc(${depth} * var(--space-12))` }}
+    <TabCard Icon={LayersIcon} title="メッシュ構造">
+      <button
+        type="button"
+        className={styles.pickToggle}
+        aria-pressed={pickingEnabled}
+        onClick={() => setPickingEnabled(!pickingEnabled)}
       >
-        {hasChildren ? (
-          <button
-            type="button"
-            className={styles.toggle}
-            onClick={() => setOpen((value) => !value)}
-            aria-label={open ? "折りたたむ" : "展開する"}
-          >
-            {open ? "▾" : "▸"}
-          </button>
-        ) : (
-          <span className={styles.toggleSpacer} />
-        )}
-        <button
-          type="button"
-          className={styles.label}
-          onClick={() => onSelect(isSelected ? null : node.uuid)}
-        >
-          <NodeIcon size={12} />
-          <span className={styles.name}>{node.name}</span>
-        </button>
-      </div>
-      {hasChildren && open && (
-        <ul role="group" className={styles.group}>
-          {node.children.map((child) => (
-            <TreeNode
-              key={child.uuid}
-              node={child}
-              depth={depth + 1}
-              selectedUuid={selectedUuid}
-              onSelect={onSelect}
-            />
-          ))}
+        <span className={`${styles.check} ${pickingEnabled ? styles.checkOn : ""}`} aria-hidden="true">
+          {pickingEnabled && <CheckIcon size={9} />}
+        </span>
+        <span className={styles.pickLabel}>右のビューアーでクリックしてメッシュを選択する</span>
+      </button>
+
+      <div className={styles.treeWrap}>
+        <ul className={styles.tree} role="tree">
+          {rows.map(({ node, depth }) => {
+            const hasChildren = node.children.length > 0;
+            const open = !collapsed.has(node.uuid);
+            const isSelected = selectedUuid === node.uuid;
+            const NodeIcon = node.isMesh ? CubeIcon : LayersIcon;
+            return (
+              <li
+                key={node.uuid}
+                role="treeitem"
+                aria-selected={isSelected}
+                aria-expanded={hasChildren ? open : undefined}
+                className={`${styles.row} ${isSelected ? styles.rowSelected : ""}`}
+                style={{ paddingLeft: `calc(${depth} * var(--space-12))` }}
+              >
+                {hasChildren ? (
+                  <button
+                    type="button"
+                    className={styles.toggle}
+                    onClick={() => toggleCollapse(node.uuid)}
+                    aria-label={open ? "折りたたむ" : "展開する"}
+                  >
+                    {open ? "▾" : "▸"}
+                  </button>
+                ) : (
+                  <span className={styles.toggleSpacer} />
+                )}
+                <button
+                  type="button"
+                  className={styles.label}
+                  onClick={() => selectMesh(isSelected ? null : node.uuid)}
+                >
+                  <NodeIcon size={12} />
+                  <span className={styles.name}>{node.name}</span>
+                </button>
+              </li>
+            );
+          })}
         </ul>
-      )}
-    </li>
+      </div>
+
+      <button type="button" className={styles.cta} onClick={() => setMode("optimize")}>
+        <ZapIcon size={16} />
+        <span className={styles.ctaLabel}>ポリゴンの最適化をする</span>
+        <ArrowRightIcon size={16} />
+      </button>
+    </TabCard>
   );
 }

--- a/app/(v2)/features/preview/MeshTab.tsx
+++ b/app/(v2)/features/preview/MeshTab.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import type { StageController, MeshNode } from "../../viewer/useThreeStage";
-import { LayersIcon } from "../../icons";
+import { LayersIcon, CubeIcon } from "../../icons";
 import { TabCard } from "./TabCard";
 import styles from "./MeshTab.module.scss";
 
@@ -32,6 +32,7 @@ function TreeNode({ node, depth, selectedUuid, onSelect }: TreeNodeProps) {
   const [open, setOpen] = useState(true);
   const hasChildren = node.children.length > 0;
   const isSelected = selectedUuid === node.uuid;
+  const NodeIcon = node.isMesh ? CubeIcon : LayersIcon;
 
   return (
     <li role="treeitem" aria-selected={isSelected} aria-expanded={hasChildren ? open : undefined}>
@@ -56,8 +57,8 @@ function TreeNode({ node, depth, selectedUuid, onSelect }: TreeNodeProps) {
           className={styles.label}
           onClick={() => onSelect(isSelected ? null : node.uuid)}
         >
+          <NodeIcon size={12} />
           <span className={styles.name}>{node.name}</span>
-          {node.isMesh && <span className={styles.badge}>mesh</span>}
         </button>
       </div>
       {hasChildren && open && (

--- a/app/(v2)/features/preview/ModelWorkspace.tsx
+++ b/app/(v2)/features/preview/ModelWorkspace.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useModelStore } from "../../store/modelStore";
+import { useThreeStage } from "../../viewer/useThreeStage";
+import { Stage } from "../../viewer/Stage";
+import { FileDropzone } from "../../components/FileDropzone";
+import { Copyright } from "../../components/Copyright";
+import { PreviewSidebar } from "./PreviewSidebar";
+import styles from "../../styles/page.module.scss";
+
+/**
+ * Workspace shown once a model is loaded. Owns the single shared 3D stage so it
+ * persists across mode switches, and lays out the preview sidebar + viewer.
+ */
+export function ModelWorkspace() {
+  const bytes = useModelStore((state) => state.originalBytes);
+  const stage = useThreeStage(bytes);
+
+  return (
+    <>
+      <aside className={styles.sidebar}>
+        <FileDropzone />
+        <PreviewSidebar stage={stage} />
+      </aside>
+      <section className={styles.viewer} aria-label="3Dビュー">
+        <Stage
+          containerRef={stage.containerRef}
+          onPointerDown={stage.onPointerDown}
+          onPointerUp={stage.onPointerUp}
+          hasAnimation={stage.animations.length > 0}
+          isPlaying={stage.isPlaying}
+          onTogglePlay={stage.togglePlay}
+          onResetView={stage.resetView}
+        />
+        <Copyright />
+      </section>
+    </>
+  );
+}

--- a/app/(v2)/features/preview/PreviewSidebar.tsx
+++ b/app/(v2)/features/preview/PreviewSidebar.tsx
@@ -1,0 +1,13 @@
+import { ModelSummaryCard } from "../../components/ModelSummaryCard";
+import type { StageController } from "../../viewer/useThreeStage";
+import { ContextTabs } from "./ContextTabs";
+
+/** Preview-mode sidebar: model overview header + contextual tabs. */
+export function PreviewSidebar({ stage }: { stage: StageController }) {
+  return (
+    <>
+      <ModelSummaryCard />
+      <ContextTabs stage={stage} />
+    </>
+  );
+}

--- a/app/(v2)/features/preview/TabCard.module.scss
+++ b/app/(v2)/features/preview/TabCard.module.scss
@@ -1,0 +1,29 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+  width: 100%;
+  padding: var(--space-18);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.sectionTitle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  width: 100%;
+}
+
+.sectionIcon {
+  display: inline-flex;
+  color: var(--color-accent);
+}
+
+.sectionLabel {
+  font-weight: 600;
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-text);
+}

--- a/app/(v2)/features/preview/TabCard.tsx
+++ b/app/(v2)/features/preview/TabCard.tsx
@@ -1,0 +1,23 @@
+import type { IconProps } from "../../icons";
+import styles from "./TabCard.module.scss";
+
+interface TabCardProps {
+  Icon: (props: IconProps) => React.ReactElement;
+  title: string;
+  children: React.ReactNode;
+}
+
+/** White card with a section title, shared by the preview context tabs. */
+export function TabCard({ Icon, title, children }: TabCardProps) {
+  return (
+    <div className={styles.card}>
+      <div className={styles.sectionTitle}>
+        <span className={styles.sectionIcon}>
+          <Icon size={14} />
+        </span>
+        <span className={styles.sectionLabel}>{title}</span>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/app/(v2)/icons/index.tsx
+++ b/app/(v2)/icons/index.tsx
@@ -43,6 +43,10 @@ export const CheckIcon = (props: IconProps) => (
 export const CircleIcon = (props: IconProps) => (
   <Icon {...props}><circle cx="12" cy="12" r="9" /></Icon>
 );
+// Material sphere: circle with a specular-highlight arc.
+export const SphereIcon = (props: IconProps) => (
+  <Icon {...props}><circle cx="12" cy="12" r="9" /><path d="M8.5 8a5 5 0 0 1 4-1.8" /></Icon>
+);
 export const CubeIcon = (props: IconProps) => (
   <Icon {...props}><path d="M21 8l-9-5-9 5v8l9 5 9-5z" /><path d="M3 8l9 5 9-5" /><path d="M12 13v8" /></Icon>
 );

--- a/app/(v2)/icons/index.tsx
+++ b/app/(v2)/icons/index.tsx
@@ -40,6 +40,9 @@ export const CameraIcon = (props: IconProps) => (
 export const CheckIcon = (props: IconProps) => (
   <Icon {...props}><path d="M20 6 9 17l-5-5" /></Icon>
 );
+export const CircleIcon = (props: IconProps) => (
+  <Icon {...props}><circle cx="12" cy="12" r="9" /></Icon>
+);
 export const CubeIcon = (props: IconProps) => (
   <Icon {...props}><path d="M21 8l-9-5-9 5v8l9 5 9-5z" /><path d="M3 8l9 5 9-5" /><path d="M12 13v8" /></Icon>
 );

--- a/app/(v2)/lib/glbTextureSizes.ts
+++ b/app/(v2)/lib/glbTextureSizes.ts
@@ -1,0 +1,87 @@
+// Extract encoded texture byte sizes from a glb, keyed by material name and the
+// three.js map type. GLTFLoader decodes images to bitmaps and drops the encoded
+// byte length, so we read it back from the glb's JSON chunk (bufferView sizes).
+
+const GLB_MAGIC = 0x46546c67; // "glTF"
+const JSON_CHUNK = 0x4e4f534a; // "JSON"
+
+/** glTF texture slot → three.js map-type label(s). Roughness/Metalness share one. */
+const SLOTS: { label: string; index: (material: GltfMaterial) => number | undefined }[] = [
+  { label: "BaseColor", index: (m) => m.pbrMetallicRoughness?.baseColorTexture?.index },
+  { label: "Normal", index: (m) => m.normalTexture?.index },
+  { label: "Roughness", index: (m) => m.pbrMetallicRoughness?.metallicRoughnessTexture?.index },
+  { label: "Metalness", index: (m) => m.pbrMetallicRoughness?.metallicRoughnessTexture?.index },
+  { label: "Emissive", index: (m) => m.emissiveTexture?.index },
+  { label: "AO", index: (m) => m.occlusionTexture?.index },
+];
+
+interface GltfMaterial {
+  name?: string;
+  normalTexture?: { index?: number };
+  emissiveTexture?: { index?: number };
+  occlusionTexture?: { index?: number };
+  pbrMetallicRoughness?: {
+    baseColorTexture?: { index?: number };
+    metallicRoughnessTexture?: { index?: number };
+  };
+}
+
+interface GltfJson {
+  materials?: GltfMaterial[];
+  textures?: { source?: number }[];
+  images?: { bufferView?: number }[];
+  bufferViews?: { byteLength?: number }[];
+}
+
+export type MaterialTextureSizes = Map<string, Record<string, number>>;
+
+export function parseGlbTextureSizes(bytes: ArrayBuffer): MaterialTextureSizes {
+  const result: MaterialTextureSizes = new Map();
+  try {
+    const view = new DataView(bytes);
+    if (view.byteLength < 12 || view.getUint32(0, true) !== GLB_MAGIC) {
+      return result;
+    }
+    let offset = 12;
+    let json: GltfJson | null = null;
+    while (offset + 8 <= view.byteLength) {
+      const chunkLength = view.getUint32(offset, true);
+      const chunkType = view.getUint32(offset + 4, true);
+      if (chunkType === JSON_CHUNK) {
+        const chunk = new Uint8Array(bytes, offset + 8, chunkLength);
+        json = JSON.parse(new TextDecoder().decode(chunk)) as GltfJson;
+        break;
+      }
+      offset += 8 + chunkLength;
+    }
+    if (!json?.materials) {
+      return result;
+    }
+
+    const imageBytes = (textureIndex: number | undefined): number => {
+      if (textureIndex == null) {
+        return 0;
+      }
+      const source = json.textures?.[textureIndex]?.source;
+      const bufferView = source != null ? json.images?.[source]?.bufferView : undefined;
+      return bufferView != null ? json.bufferViews?.[bufferView]?.byteLength ?? 0 : 0;
+    };
+
+    json.materials.forEach((material) => {
+      if (!material.name) {
+        return;
+      }
+      const sizes: Record<string, number> = {};
+      SLOTS.forEach(({ label, index }) => {
+        const bytesLength = imageBytes(index(material));
+        if (bytesLength > 0) {
+          sizes[label] = bytesLength;
+        }
+      });
+      result.set(material.name, sizes);
+    });
+  } catch {
+    // Non-standard glb — sizes just stay unavailable.
+  }
+  return result;
+}

--- a/app/(v2)/page.tsx
+++ b/app/(v2)/page.tsx
@@ -4,16 +4,13 @@ import { useModelStore } from "./store/modelStore";
 import { Header } from "./components/Header";
 import { ServiceInfo } from "./components/ServiceInfo";
 import { FileDropzone } from "./components/FileDropzone";
-import { ModelSummaryCard } from "./components/ModelSummaryCard";
 import { Copyright } from "./components/Copyright";
-import { Stage } from "./viewer/Stage";
+import { ModelWorkspace } from "./features/preview/ModelWorkspace";
 import styles from "./styles/page.module.scss";
 
 /**
- * v2 landing (`/`). The shell (header, mode switch, theme) plus the model
- * upload flow. Uploading a `.glb` fills modelStore and switches the sidebar
- * to the model overview (Figma preview screen). The 3D viewer, context tabs
- * and optimization UI that consume that state arrive in later issues.
+ * v2 landing (`/`). Empty state = service info + hero uploader; once a `.glb`
+ * is loaded, the ModelWorkspace takes over (preview sidebar + 3D viewer).
  */
 export default function V2Page() {
   const hasModel = useModelStore((state) => state.originalBytes !== null);
@@ -22,26 +19,21 @@ export default function V2Page() {
     <>
       <Header />
       <main className={styles.main}>
-        <aside className={styles.sidebar}>
-          {hasModel ? (
-            <>
-              <FileDropzone />
-              <ModelSummaryCard />
-            </>
-          ) : (
-            <ServiceInfo />
-          )}
-        </aside>
-        <section className={styles.viewer} aria-label="3Dビュー">
-          {hasModel ? (
-            <Stage />
-          ) : (
-            <div className={styles.viewerBody}>
-              <FileDropzone variant="hero" />
-            </div>
-          )}
-          <Copyright />
-        </section>
+        {hasModel ? (
+          <ModelWorkspace />
+        ) : (
+          <>
+            <aside className={styles.sidebar}>
+              <ServiceInfo />
+            </aside>
+            <section className={styles.viewer} aria-label="3Dビュー">
+              <div className={styles.viewerBody}>
+                <FileDropzone variant="hero" />
+              </div>
+              <Copyright />
+            </section>
+          </>
+        )}
       </main>
     </>
   );

--- a/app/(v2)/styles/global.scss
+++ b/app/(v2)/styles/global.scss
@@ -9,7 +9,8 @@ body {
 [data-app="v2"] {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
   background: var(--color-bg);
   color: var(--color-text);
   font-family: var(--font-sans);

--- a/app/(v2)/styles/page.module.scss
+++ b/app/(v2)/styles/page.module.scss
@@ -9,8 +9,11 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-20);
+  min-width: 0;
+  width: 380px;
   padding: var(--space-20);
   border-right: 1px solid var(--color-border);
+  overflow-y: auto;
 }
 
 .viewer {

--- a/app/(v2)/styles/tokens.scss
+++ b/app/(v2)/styles/tokens.scss
@@ -12,6 +12,7 @@
 
   // Surface & text ramp (light)
   --color-bg: #f7f5f2; // Figma color/biege-3
+  --color-viewer-bg: #ffffff; // 3D viewer backdrop (white in light)
   --color-surface: #ffffff; // Figma color/white — cards, active tab
   --color-track: #eeece8; // Figma color/biege-10 — segmented control track
   --color-border: #e6e3de; // Figma color/black-1
@@ -59,6 +60,7 @@
   --color-highlight: #6f9bff;
 
   --color-bg: #1b1a18;
+  --color-viewer-bg: #1b1a18; // dark: unchanged (matches the app background)
   --color-surface: #232220;
   --color-track: #2b2a27;
   --color-border: #3a3833;

--- a/app/(v2)/styles/tokens.scss
+++ b/app/(v2)/styles/tokens.scss
@@ -8,6 +8,7 @@
   --color-accent-strong: #ed4f14; // hover / pressed
   --color-on-accent: #ffffff; // text/icon on an accent fill
   --color-highlight: #2f6bff; // Figma color/blue-8 — upload icon, notes, focus
+  --color-highlight-soft: #eaf0ff; // Figma color/blue-2 — selected row background
 
   // Surface & text ramp (light)
   --color-bg: #f7f5f2; // Figma color/biege-3
@@ -63,6 +64,7 @@
   --color-text: #f4ede2;
   --color-text-muted: #b3a99c;
   --color-text-faint: #8f887c;
+  --color-highlight-soft: #23324d;
 
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.5);
 }

--- a/app/(v2)/styles/tokens.scss
+++ b/app/(v2)/styles/tokens.scss
@@ -15,6 +15,7 @@
   --color-surface: #ffffff; // Figma color/white — cards, active tab
   --color-track: #eeece8; // Figma color/biege-10 — segmented control track
   --color-border: #e6e3de; // Figma color/black-1
+  --color-border-2: #d3cfc8; // Figma color/black-2 — visible track / control line
   --color-text: #26241f; // Figma color/black-10
   --color-text-muted: #66625a; // Figma color/black-6 — inactive tab label
   --color-text-faint: #928d84; // Figma color/black-5 — v2.0, copyright, subtitle
@@ -61,6 +62,7 @@
   --color-surface: #232220;
   --color-track: #2b2a27;
   --color-border: #3a3833;
+  --color-border-2: #4a4842;
   --color-text: #f4ede2;
   --color-text-muted: #b3a99c;
   --color-text-faint: #8f887c;

--- a/app/(v2)/viewer/Stage.module.scss
+++ b/app/(v2)/viewer/Stage.module.scss
@@ -2,6 +2,7 @@
   flex: 1;
   position: relative;
   min-height: 0;
+  background: var(--color-viewer-bg);
 }
 
 .canvas {

--- a/app/(v2)/viewer/Stage.module.scss
+++ b/app/(v2)/viewer/Stage.module.scss
@@ -14,18 +14,3 @@
     display: block;
   }
 }
-
-.selected {
-  position: absolute;
-  top: var(--space-12);
-  left: var(--space-12);
-  z-index: 1;
-  padding: var(--space-4) var(--space-8);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-pill);
-  background: var(--color-surface);
-  color: var(--color-text);
-  font-size: var(--font-size-11);
-  line-height: 14px;
-  box-shadow: var(--shadow-sm);
-}

--- a/app/(v2)/viewer/Stage.tsx
+++ b/app/(v2)/viewer/Stage.tsx
@@ -1,24 +1,29 @@
 "use client";
 
-import { useModelStore } from "../store/modelStore";
-import { useThreeStage } from "./useThreeStage";
+import type { Ref } from "react";
 import { ViewerToolbar } from "./ViewerToolbar";
 import styles from "./Stage.module.scss";
 
-/** 3D preview of the uploaded glb, driven by the `useThreeStage` hook. */
-export function Stage() {
-  const bytes = useModelStore((state) => state.originalBytes);
-  const {
-    containerRef,
-    animations,
-    isPlaying,
-    selectedName,
-    onPointerDown,
-    onPointerUp,
-    togglePlay,
-    resetView,
-  } = useThreeStage(bytes);
+interface StageProps {
+  containerRef: Ref<HTMLDivElement>;
+  onPointerDown: (event: React.PointerEvent) => void;
+  onPointerUp: (event: React.PointerEvent) => void;
+  hasAnimation: boolean;
+  isPlaying: boolean;
+  onTogglePlay: () => void;
+  onResetView: () => void;
+}
 
+/** Presentational 3D canvas host. The stage is driven by `useThreeStage`. */
+export function Stage({
+  containerRef,
+  onPointerDown,
+  onPointerUp,
+  hasAnimation,
+  isPlaying,
+  onTogglePlay,
+  onResetView,
+}: StageProps) {
   return (
     <div className={styles.stage}>
       <div
@@ -27,12 +32,11 @@ export function Stage() {
         onPointerDown={onPointerDown}
         onPointerUp={onPointerUp}
       />
-      {selectedName && <span className={styles.selected}>選択中: {selectedName}</span>}
       <ViewerToolbar
-        hasAnimation={animations.length > 0}
+        hasAnimation={hasAnimation}
         isPlaying={isPlaying}
-        onTogglePlay={togglePlay}
-        onResetView={resetView}
+        onTogglePlay={onTogglePlay}
+        onResetView={onResetView}
       />
     </div>
   );

--- a/app/(v2)/viewer/useThreeStage.ts
+++ b/app/(v2)/viewer/useThreeStage.ts
@@ -130,6 +130,7 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
   const clockRef = useRef(new THREE.Clock());
   const raycasterRef = useRef(new THREE.Raycaster());
   const pointerDownRef = useRef<{ x: number; y: number } | null>(null);
+  const isPlayingRef = useRef(false);
   const setMeta = useModelStore((state) => state.setMeta);
 
   const [animations, setAnimations] = useState<StageAnimation[]>([]);
@@ -140,6 +141,11 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
   const [materials, setMaterials] = useState<MaterialInfo[]>([]);
   const [meshTree, setMeshTree] = useState<MeshNode | null>(null);
   const [selectedUuid, setSelectedUuid] = useState<string | null>(null);
+
+  // Keep a ref in sync so the render loop can gate the mixer without re-running.
+  useEffect(() => {
+    isPlayingRef.current = isPlaying;
+  }, [isPlaying]);
 
   const applySelection = useCallback((uuid: string | null) => {
     const stage = refs.current;
@@ -227,7 +233,7 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
         return;
       }
       const delta = clockRef.current.getDelta();
-      if (current.mixer) {
+      if (current.mixer && isPlayingRef.current) {
         current.mixer.update(delta);
         // Throttle time updates to ~10/s to avoid re-rendering every frame.
         const deci = Math.floor(current.mixer.time * 10);
@@ -402,15 +408,9 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
     if (!stage || !stage.mixer) {
       return;
     }
-    setIsPlaying((playing) => {
-      const next = !playing;
-      stage.actions.forEach((action) => {
-        if (!action.paused || action.isRunning()) {
-          action.paused = !next;
-        }
-      });
-      return next;
-    });
+    // The render loop gates mixer.update on isPlaying, so flipping the flag both
+    // freezes the pose and stops the seek time from advancing.
+    setIsPlaying((playing) => !playing);
   }, []);
 
   const toggleClip = useCallback((name: string) => {

--- a/app/(v2)/viewer/useThreeStage.ts
+++ b/app/(v2)/viewer/useThreeStage.ts
@@ -8,6 +8,7 @@ import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
 import { OutlinePass } from "three/examples/jsm/postprocessing/OutlinePass.js";
 import { OutputPass } from "three/examples/jsm/postprocessing/OutputPass.js";
 import { useModelStore } from "../store/modelStore";
+import { parseGlbTextureSizes, type MaterialTextureSizes } from "../lib/glbTextureSizes";
 
 const OUTLINE_COLOR = "#2f6bff"; // v2 highlight (electric blue)
 const CLICK_DRAG_THRESHOLD = 4; // px — distinguishes a pick from an orbit drag
@@ -23,6 +24,7 @@ export interface MaterialTextureInfo {
   name: string;
   width: number;
   height: number;
+  byteLength: number;
 }
 
 export interface MaterialInfo {
@@ -112,7 +114,8 @@ function countTriangles(root: THREE.Object3D): number {
 
 function collectMaterials(
   root: THREE.Object3D,
-  registry: Map<string, THREE.Material>
+  registry: Map<string, THREE.Material>,
+  textureSizes: MaterialTextureSizes
 ): MaterialInfo[] {
   const infos: MaterialInfo[] = [];
   root.traverse((object) => {
@@ -126,11 +129,12 @@ function collectMaterials(
       registry.set(entry.uuid, entry);
       const standard = entry as THREE.MeshStandardMaterial;
       const record = standard as unknown as Record<string, THREE.Texture | undefined>;
+      const sizes = textureSizes.get(entry.name) ?? {};
       const textures: MaterialTextureInfo[] = [];
       MAP_KEYS.forEach(({ key, label }) => {
         const thumb = textureThumbnail(record[key]);
         if (thumb) {
-          textures.push({ type: label, ...thumb });
+          textures.push({ type: label, byteLength: sizes[label] ?? 0, ...thumb });
         }
       });
       infos.push({
@@ -377,7 +381,7 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
           polygons: countTriangles(model),
         });
         stage.materials = new Map();
-        setMaterials(collectMaterials(model, stage.materials));
+        setMaterials(collectMaterials(model, stage.materials, parseGlbTextureSizes(bytes)));
         setMeshTree(buildMeshTree(model));
 
         // Fit camera to the model bounds.

--- a/app/(v2)/viewer/useThreeStage.ts
+++ b/app/(v2)/viewer/useThreeStage.ts
@@ -131,6 +131,7 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
   const raycasterRef = useRef(new THREE.Raycaster());
   const pointerDownRef = useRef<{ x: number; y: number } | null>(null);
   const isPlayingRef = useRef(false);
+  const activeClipsRef = useRef<string[]>([]);
   const setMeta = useModelStore((state) => state.setMeta);
 
   const [animations, setAnimations] = useState<StageAnimation[]>([]);
@@ -142,10 +143,13 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
   const [meshTree, setMeshTree] = useState<MeshNode | null>(null);
   const [selectedUuid, setSelectedUuid] = useState<string | null>(null);
 
-  // Keep a ref in sync so the render loop can gate the mixer without re-running.
+  // Keep refs in sync so the render loop can gate the mixer without re-running.
   useEffect(() => {
     isPlayingRef.current = isPlaying;
   }, [isPlaying]);
+  useEffect(() => {
+    activeClipsRef.current = activeClips;
+  }, [activeClips]);
 
   const applySelection = useCallback((uuid: string | null) => {
     const stage = refs.current;
@@ -422,17 +426,21 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
     if (!action) {
       return;
     }
-    setActiveClips((prev) => {
-      if (prev.includes(name)) {
-        action.stop();
-        return prev.filter((entry) => entry !== name);
-      }
+    const previous = activeClipsRef.current;
+    let next: string[];
+    if (previous.includes(name)) {
+      action.stop();
+      next = previous.filter((entry) => entry !== name);
+    } else {
       action.reset().play();
-      const clipDuration = stage.clips.get(name)?.duration ?? 0;
-      setDuration((current) => Math.max(current, clipDuration));
-      setIsPlaying(true);
-      return [...prev, name];
-    });
+      next = [...previous, name];
+    }
+    setActiveClips(next);
+    // Pause playback (and freeze the seek) when nothing is selected.
+    setIsPlaying(next.length > 0);
+    setDuration(
+      next.reduce((max, clip) => Math.max(max, stage.clips.get(clip)?.duration ?? 0), 0)
+    );
   }, []);
 
   const seek = useCallback((time: number) => {

--- a/app/(v2)/viewer/useThreeStage.ts
+++ b/app/(v2)/viewer/useThreeStage.ts
@@ -61,7 +61,7 @@ function textureThumbnail(
     return null;
   }
   try {
-    const size = 56;
+    const size = 128;
     const canvas = document.createElement("canvas");
     canvas.width = size;
     canvas.height = size;

--- a/app/(v2)/viewer/useThreeStage.ts
+++ b/app/(v2)/viewer/useThreeStage.ts
@@ -17,12 +17,17 @@ export interface StageAnimation {
   duration: number;
 }
 
+export interface MaterialTextureInfo {
+  type: string;
+  url: string;
+}
+
 export interface MaterialInfo {
   id: string;
   name: string;
   roughness: number;
   metalness: number;
-  maps: string[];
+  textures: MaterialTextureInfo[];
 }
 
 export interface MeshNode {
@@ -33,7 +38,36 @@ export interface MeshNode {
   children: MeshNode[];
 }
 
-const MAP_KEYS = ["map", "normalMap", "roughnessMap", "metalnessMap", "emissiveMap", "aoMap"] as const;
+const MAP_KEYS: { key: string; label: string }[] = [
+  { key: "map", label: "baseColor" },
+  { key: "normalMap", label: "normal" },
+  { key: "roughnessMap", label: "roughness" },
+  { key: "metalnessMap", label: "metalness" },
+  { key: "emissiveMap", label: "emissive" },
+  { key: "aoMap", label: "ao" },
+];
+
+/** Draw a texture's source image into a small canvas and return a data URL. */
+function textureThumbnail(texture: THREE.Texture | null | undefined): string | null {
+  const image = texture?.image as CanvasImageSource | undefined;
+  if (!image) {
+    return null;
+  }
+  try {
+    const size = 56;
+    const canvas = document.createElement("canvas");
+    canvas.width = size;
+    canvas.height = size;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      return null;
+    }
+    context.drawImage(image, 0, 0, size, size);
+    return canvas.toDataURL("image/png");
+  } catch {
+    return null;
+  }
+}
 
 /** Free GPU resources held by a model subtree before discarding it. */
 function disposeObject(root: THREE.Object3D) {
@@ -81,12 +115,20 @@ function collectMaterials(
       }
       registry.set(entry.uuid, entry);
       const standard = entry as THREE.MeshStandardMaterial;
+      const record = standard as unknown as Record<string, THREE.Texture | undefined>;
+      const textures: MaterialTextureInfo[] = [];
+      MAP_KEYS.forEach(({ key, label }) => {
+        const url = textureThumbnail(record[key]);
+        if (url) {
+          textures.push({ type: label, url });
+        }
+      });
       infos.push({
         id: entry.uuid,
         name: entry.name || "Material",
         roughness: typeof standard.roughness === "number" ? standard.roughness : 0,
         metalness: typeof standard.metalness === "number" ? standard.metalness : 0,
-        maps: MAP_KEYS.filter((key) => (standard as unknown as Record<string, unknown>)[key]),
+        textures,
       });
     });
   });
@@ -142,6 +184,8 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
   const [materials, setMaterials] = useState<MaterialInfo[]>([]);
   const [meshTree, setMeshTree] = useState<MeshNode | null>(null);
   const [selectedUuid, setSelectedUuid] = useState<string | null>(null);
+  const [pickingEnabled, setPickingEnabled] = useState(true);
+  const pickingEnabledRef = useRef(true);
 
   // Keep refs in sync so the render loop can gate the mixer without re-running.
   useEffect(() => {
@@ -150,6 +194,9 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
   useEffect(() => {
     activeClipsRef.current = activeClips;
   }, [activeClips]);
+  useEffect(() => {
+    pickingEnabledRef.current = pickingEnabled;
+  }, [pickingEnabled]);
 
   const applySelection = useCallback((uuid: string | null) => {
     const stage = refs.current;
@@ -383,7 +430,7 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
       const start = pointerDownRef.current;
       pointerDownRef.current = null;
       const stage = refs.current;
-      if (!start || !stage || !stage.model) {
+      if (!start || !stage || !stage.model || !pickingEnabledRef.current) {
         return;
       }
       if (Math.hypot(event.clientX - start.x, event.clientY - start.y) > CLICK_DRAG_THRESHOLD) {
@@ -499,6 +546,8 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
     meshTree,
     selectedUuid,
     selectMesh,
+    pickingEnabled,
+    setPickingEnabled,
     resetView,
   };
 }

--- a/app/(v2)/viewer/useThreeStage.ts
+++ b/app/(v2)/viewer/useThreeStage.ts
@@ -7,9 +7,33 @@ import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer
 import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
 import { OutlinePass } from "three/examples/jsm/postprocessing/OutlinePass.js";
 import { OutputPass } from "three/examples/jsm/postprocessing/OutputPass.js";
+import { useModelStore } from "../store/modelStore";
 
 const OUTLINE_COLOR = "#2f6bff"; // v2 highlight (electric blue)
 const CLICK_DRAG_THRESHOLD = 4; // px — distinguishes a pick from an orbit drag
+
+export interface StageAnimation {
+  name: string;
+  duration: number;
+}
+
+export interface MaterialInfo {
+  id: string;
+  name: string;
+  roughness: number;
+  metalness: number;
+  maps: string[];
+}
+
+export interface MeshNode {
+  uuid: string;
+  name: string;
+  type: string;
+  isMesh: boolean;
+  children: MeshNode[];
+}
+
+const MAP_KEYS = ["map", "normalMap", "roughnessMap", "metalnessMap", "emissiveMap", "aoMap"] as const;
 
 /** Free GPU resources held by a model subtree before discarding it. */
 function disposeObject(root: THREE.Object3D) {
@@ -29,9 +53,54 @@ function disposeObject(root: THREE.Object3D) {
   });
 }
 
-export interface StageAnimation {
-  name: string;
-  duration: number;
+function countTriangles(root: THREE.Object3D): number {
+  let triangles = 0;
+  root.traverse((object) => {
+    const mesh = object as THREE.Mesh;
+    if (mesh.isMesh && mesh.geometry) {
+      const index = mesh.geometry.index;
+      const position = mesh.geometry.attributes.position;
+      triangles += (index ? index.count : position ? position.count : 0) / 3;
+    }
+  });
+  return Math.round(triangles);
+}
+
+function collectMaterials(
+  root: THREE.Object3D,
+  registry: Map<string, THREE.Material>
+): MaterialInfo[] {
+  const infos: MaterialInfo[] = [];
+  root.traverse((object) => {
+    const mesh = object as THREE.Mesh;
+    const material = mesh.material;
+    const materials = Array.isArray(material) ? material : material ? [material] : [];
+    materials.forEach((entry) => {
+      if (registry.has(entry.uuid)) {
+        return;
+      }
+      registry.set(entry.uuid, entry);
+      const standard = entry as THREE.MeshStandardMaterial;
+      infos.push({
+        id: entry.uuid,
+        name: entry.name || "Material",
+        roughness: typeof standard.roughness === "number" ? standard.roughness : 0,
+        metalness: typeof standard.metalness === "number" ? standard.metalness : 0,
+        maps: MAP_KEYS.filter((key) => (standard as unknown as Record<string, unknown>)[key]),
+      });
+    });
+  });
+  return infos;
+}
+
+function buildMeshTree(object: THREE.Object3D): MeshNode {
+  return {
+    uuid: object.uuid,
+    name: object.name || object.type,
+    type: object.type,
+    isMesh: (object as THREE.Mesh).isMesh === true,
+    children: object.children.map(buildMeshTree),
+  };
 }
 
 interface StageRefs {
@@ -44,13 +113,16 @@ interface StageRefs {
   mixer: THREE.AnimationMixer | null;
   model: THREE.Object3D | null;
   actions: Map<string, THREE.AnimationAction>;
+  clips: Map<string, THREE.AnimationClip>;
+  materials: Map<string, THREE.Material>;
+  objectsByUuid: Map<string, THREE.Object3D>;
 }
 
 /**
- * Owns the three.js stage (renderer / scene / camera / controls / composer)
- * and renders a glb passed as bytes. Plain three.js behind a thin hook — three
- * objects live in refs (never in React state / the store). Selection uses a
- * Raycaster + OutlinePass; animation uses an AnimationMixer.
+ * Owns the three.js stage and renders a glb passed as bytes. Plain three.js
+ * behind a thin hook — three objects live in refs (never in React state / the
+ * store). Exposes serializable model data (polygons, materials, mesh tree,
+ * animations) and imperative controls for the preview UI to drive.
  */
 export function useThreeStage(bytes: ArrayBuffer | null) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -58,10 +130,26 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
   const clockRef = useRef(new THREE.Clock());
   const raycasterRef = useRef(new THREE.Raycaster());
   const pointerDownRef = useRef<{ x: number; y: number } | null>(null);
+  const setMeta = useModelStore((state) => state.setMeta);
 
   const [animations, setAnimations] = useState<StageAnimation[]>([]);
+  const [activeClips, setActiveClips] = useState<string[]>([]);
   const [isPlaying, setIsPlaying] = useState(false);
-  const [selectedName, setSelectedName] = useState<string | null>(null);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [materials, setMaterials] = useState<MaterialInfo[]>([]);
+  const [meshTree, setMeshTree] = useState<MeshNode | null>(null);
+  const [selectedUuid, setSelectedUuid] = useState<string | null>(null);
+
+  const applySelection = useCallback((uuid: string | null) => {
+    const stage = refs.current;
+    if (!stage) {
+      return;
+    }
+    const object = uuid ? stage.objectsByUuid.get(uuid) : null;
+    stage.outlinePass.selectedObjects = object ? [object] : [];
+    setSelectedUuid(object ? uuid : null);
+  }, []);
 
   // ── Stage lifecycle (mount once) ─────────────────────────────────────────
   useEffect(() => {
@@ -92,7 +180,6 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
     renderer.toneMappingExposure = 1;
     container.appendChild(renderer.domElement);
 
-    // Match legacy exactly: sharp RoomEnvironment IBL (no PMREM blur sigma).
     const pmrem = new THREE.PMREMGenerator(renderer);
     scene.environment = pmrem.fromScene(new RoomEnvironment()).texture;
 
@@ -114,8 +201,6 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
     outlinePass.edgeThickness = 1;
     composer.addPass(outlinePass);
     // OutputPass applies tone mapping + sRGB conversion to the composed frame.
-    // Without it, EffectComposer emits linear color and materials look far too
-    // saturated/dark (matches the legacy viewer's pipeline).
     composer.addPass(new OutputPass());
 
     refs.current = {
@@ -128,9 +213,13 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
       mixer: null,
       model: null,
       actions: new Map(),
+      clips: new Map(),
+      materials: new Map(),
+      objectsByUuid: new Map(),
     };
 
     let raf = 0;
+    let lastDeci = -1;
     const renderLoop = () => {
       raf = requestAnimationFrame(renderLoop);
       const current = refs.current;
@@ -138,7 +227,15 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
         return;
       }
       const delta = clockRef.current.getDelta();
-      current.mixer?.update(delta);
+      if (current.mixer) {
+        current.mixer.update(delta);
+        // Throttle time updates to ~10/s to avoid re-rendering every frame.
+        const deci = Math.floor(current.mixer.time * 10);
+        if (deci !== lastDeci) {
+          lastDeci = deci;
+          setCurrentTime(current.mixer.time);
+        }
+      }
       current.controls.update();
       current.composer.render();
     };
@@ -196,11 +293,25 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
           disposeObject(stage.model);
         }
         stage.outlinePass.selectedObjects = [];
-        setSelectedName(null);
+        setSelectedUuid(null);
 
         const model = gltf.scene;
         stage.scene.add(model);
         stage.model = model;
+
+        // Index objects for tree ↔ viewer selection.
+        stage.objectsByUuid = new Map();
+        model.traverse((object) => stage.objectsByUuid.set(object.uuid, object));
+
+        // Extract serializable model data for the preview UI.
+        const existingMeta = useModelStore.getState().meta;
+        setMeta({
+          ...(existingMeta ?? { name: "", size: bytes.byteLength }),
+          polygons: countTriangles(model),
+        });
+        stage.materials = new Map();
+        setMaterials(collectMaterials(model, stage.materials));
+        setMeshTree(buildMeshTree(model));
 
         // Fit camera to the model bounds.
         const box = new THREE.Box3().setFromObject(model);
@@ -219,21 +330,28 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
 
         // Animation.
         stage.actions.clear();
+        stage.clips.clear();
         if (gltf.animations.length > 0) {
           const mixer = new THREE.AnimationMixer(model);
           stage.mixer = mixer;
           gltf.animations.forEach((clip) => {
             stage.actions.set(clip.name, mixer.clipAction(clip));
+            stage.clips.set(clip.name, clip);
           });
           const first = gltf.animations[0];
           stage.actions.get(first.name)?.reset().play();
-          setIsPlaying(true);
           setAnimations(gltf.animations.map((clip) => ({ name: clip.name, duration: clip.duration })));
+          setActiveClips([first.name]);
+          setDuration(first.duration);
+          setIsPlaying(true);
         } else {
           stage.mixer = null;
-          setIsPlaying(false);
           setAnimations([]);
+          setActiveClips([]);
+          setDuration(0);
+          setIsPlaying(false);
         }
+        setCurrentTime(0);
       },
       () => {
         // parse error — leave the previous scene untouched
@@ -243,41 +361,42 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
     return () => {
       cancelled = true;
     };
-  }, [bytes]);
+  }, [bytes, setMeta]);
 
   // ── Picking (click, not drag) ────────────────────────────────────────────
   const handlePointerDown = useCallback((event: React.PointerEvent) => {
     pointerDownRef.current = { x: event.clientX, y: event.clientY };
   }, []);
 
-  const handlePointerUp = useCallback((event: React.PointerEvent) => {
-    const start = pointerDownRef.current;
-    pointerDownRef.current = null;
-    const stage = refs.current;
-    if (!start || !stage || !stage.model) {
-      return;
-    }
-    if (Math.hypot(event.clientX - start.x, event.clientY - start.y) > CLICK_DRAG_THRESHOLD) {
-      return; // it was an orbit drag
-    }
-    const rect = stage.renderer.domElement.getBoundingClientRect();
-    const ndc = new THREE.Vector2(
-      ((event.clientX - rect.left) / rect.width) * 2 - 1,
-      -((event.clientY - rect.top) / rect.height) * 2 + 1
-    );
-    raycasterRef.current.setFromCamera(ndc, stage.camera);
-    const hit = raycasterRef.current.intersectObject(stage.model, true)[0];
-    const mesh = hit?.object as THREE.Mesh | undefined;
-    if (mesh) {
-      stage.outlinePass.selectedObjects = [mesh];
-      setSelectedName(mesh.name || "(no name)");
-    } else {
-      stage.outlinePass.selectedObjects = [];
-      setSelectedName(null);
-    }
-  }, []);
+  const handlePointerUp = useCallback(
+    (event: React.PointerEvent) => {
+      const start = pointerDownRef.current;
+      pointerDownRef.current = null;
+      const stage = refs.current;
+      if (!start || !stage || !stage.model) {
+        return;
+      }
+      if (Math.hypot(event.clientX - start.x, event.clientY - start.y) > CLICK_DRAG_THRESHOLD) {
+        return; // it was an orbit drag
+      }
+      const rect = stage.renderer.domElement.getBoundingClientRect();
+      const ndc = new THREE.Vector2(
+        ((event.clientX - rect.left) / rect.width) * 2 - 1,
+        -((event.clientY - rect.top) / rect.height) * 2 + 1
+      );
+      raycasterRef.current.setFromCamera(ndc, stage.camera);
+      const hit = raycasterRef.current.intersectObject(stage.model, true)[0];
+      applySelection(hit ? hit.object.uuid : null);
+    },
+    [applySelection]
+  );
 
   // ── Controls exposed to the UI ───────────────────────────────────────────
+  const selectMesh = useCallback(
+    (uuid: string | null) => applySelection(uuid),
+    [applySelection]
+  );
+
   const togglePlay = useCallback(() => {
     const stage = refs.current;
     if (!stage || !stage.mixer) {
@@ -286,11 +405,58 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
     setIsPlaying((playing) => {
       const next = !playing;
       stage.actions.forEach((action) => {
-        action.paused = !next;
+        if (!action.paused || action.isRunning()) {
+          action.paused = !next;
+        }
       });
       return next;
     });
   }, []);
+
+  const toggleClip = useCallback((name: string) => {
+    const stage = refs.current;
+    if (!stage) {
+      return;
+    }
+    const action = stage.actions.get(name);
+    if (!action) {
+      return;
+    }
+    setActiveClips((prev) => {
+      if (prev.includes(name)) {
+        action.stop();
+        return prev.filter((entry) => entry !== name);
+      }
+      action.reset().play();
+      const clipDuration = stage.clips.get(name)?.duration ?? 0;
+      setDuration((current) => Math.max(current, clipDuration));
+      setIsPlaying(true);
+      return [...prev, name];
+    });
+  }, []);
+
+  const seek = useCallback((time: number) => {
+    const stage = refs.current;
+    if (!stage || !stage.mixer) {
+      return;
+    }
+    stage.mixer.setTime(time);
+    setCurrentTime(time);
+  }, []);
+
+  const setMaterialParam = useCallback(
+    (id: string, key: "roughness" | "metalness", value: number) => {
+      const stage = refs.current;
+      const material = stage?.materials.get(id) as THREE.MeshStandardMaterial | undefined;
+      if (!material) {
+        return;
+      }
+      material[key] = value;
+      material.needsUpdate = true;
+      setMaterials((prev) => prev.map((entry) => (entry.id === id ? { ...entry, [key]: value } : entry)));
+    },
+    []
+  );
 
   const resetView = useCallback(() => {
     const stage = refs.current;
@@ -310,12 +476,23 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
 
   return {
     containerRef,
-    animations,
-    isPlaying,
-    selectedName,
     onPointerDown: handlePointerDown,
     onPointerUp: handlePointerUp,
+    animations,
+    activeClips,
+    isPlaying,
+    currentTime,
+    duration,
     togglePlay,
+    toggleClip,
+    seek,
+    materials,
+    setMaterialParam,
+    meshTree,
+    selectedUuid,
+    selectMesh,
     resetView,
   };
 }
+
+export type StageController = ReturnType<typeof useThreeStage>;

--- a/app/(v2)/viewer/useThreeStage.ts
+++ b/app/(v2)/viewer/useThreeStage.ts
@@ -20,6 +20,9 @@ export interface StageAnimation {
 export interface MaterialTextureInfo {
   type: string;
   url: string;
+  name: string;
+  width: number;
+  height: number;
 }
 
 export interface MaterialInfo {
@@ -39,17 +42,19 @@ export interface MeshNode {
 }
 
 const MAP_KEYS: { key: string; label: string }[] = [
-  { key: "map", label: "baseColor" },
-  { key: "normalMap", label: "normal" },
-  { key: "roughnessMap", label: "roughness" },
-  { key: "metalnessMap", label: "metalness" },
-  { key: "emissiveMap", label: "emissive" },
-  { key: "aoMap", label: "ao" },
+  { key: "map", label: "BaseColor" },
+  { key: "normalMap", label: "Normal" },
+  { key: "roughnessMap", label: "Roughness" },
+  { key: "metalnessMap", label: "Metalness" },
+  { key: "emissiveMap", label: "Emissive" },
+  { key: "aoMap", label: "AO" },
 ];
 
-/** Draw a texture's source image into a small canvas and return a data URL. */
-function textureThumbnail(texture: THREE.Texture | null | undefined): string | null {
-  const image = texture?.image as CanvasImageSource | undefined;
+/** Draw a texture's source image into a small canvas and return a data URL + size. */
+function textureThumbnail(
+  texture: THREE.Texture | null | undefined
+): { url: string; width: number; height: number; name: string } | null {
+  const image = texture?.image as (CanvasImageSource & { width?: number; height?: number }) | undefined;
   if (!image) {
     return null;
   }
@@ -63,7 +68,12 @@ function textureThumbnail(texture: THREE.Texture | null | undefined): string | n
       return null;
     }
     context.drawImage(image, 0, 0, size, size);
-    return canvas.toDataURL("image/png");
+    return {
+      url: canvas.toDataURL("image/png"),
+      width: image.width ?? 0,
+      height: image.height ?? 0,
+      name: texture?.name || (texture?.userData?.filename as string) || "",
+    };
   } catch {
     return null;
   }
@@ -118,9 +128,9 @@ function collectMaterials(
       const record = standard as unknown as Record<string, THREE.Texture | undefined>;
       const textures: MaterialTextureInfo[] = [];
       MAP_KEYS.forEach(({ key, label }) => {
-        const url = textureThumbnail(record[key]);
-        if (url) {
-          textures.push({ type: label, url });
+        const thumb = textureThumbnail(record[key]);
+        if (thumb) {
+          textures.push({ type: label, ...thumb });
         }
       });
       infos.push({


### PR DESCRIPTION
## 概要

確定 IA + Figma プレビュー画面(node 49-307)でプレビューモードを実装 (architecture §6 1-2)。共有 3D ステージを軸に、概要ヘッダー + 文脈3タブを構築。

## 変更内容

- **`viewer/useThreeStage.ts` 拡張**: モデルのシリアライズ可能データ(ポリゴン数→`modelStore.meta`、マテリアル、メッシュツリー、アニメ)と操作API(`toggleClip`/`seek`、`setMaterialParam`、`selectMesh`)を公開。ツリー⇔ビューアの双方向選択。
- **`features/preview/ModelWorkspace.tsx`**: 単一の共有ステージを保持し(モード切替で再ロードされない)、プレビューサイドバー + ビューアをレイアウト。
- **文脈タブ アニメーション/マテリアル/メッシュ**(0件タブは無効化=F-13):
  - **アニメーション**: クリップ一覧(チェックで再生切替)+ 再生/停止 + シークバー。
  - **マテリアル**: 粗さ/金属感スライダーを**プレビューにのみ即時反映(非破壊)**。テクスチャマップのチップ表示。
  - **メッシュ**: 構造ツリー。クリックでビューアのアウトライン選択と**双方向同期**。
- **`ModelSummaryCard`**: ポリゴン数の実値を表示。**copyright 行を撤去**(2026-07-20決定でUI非表示。保存時のメタ維持は 1-3)。
- 行は `button` 化 + `aria-label`、タブは `role`/`aria-selected`(F-15)。

> 軽量化モードのサイドバーは #33。本PRではモード切替でビューアは維持しつつ、サイドバーはプレビュー内容のまま(暫定)。

## 動作確認 (QA / Playwright, test.glb / 旧版比較)

- ✅ 概要ヘッダー: `test.glb` / 75.8KB / **ポリゴン数 996(実値)** / CTA。copyright 表示なし。
- ✅ アニメーション: クリップ表示・再生/停止・シーク。
- ✅ マテリアル: `red`/`white`(旧版と一致)。Roughness=0/Metalness=1 で**金属質に即時変化**(非破壊)。
- ✅ メッシュ: ツリー(Scene>エンプティ>box, parent>big_box/small_box)。ツリー→ビューア(青アウトライン)、ビューア→ツリー(aria-selected)の**双方向同期**。
- ✅ copyright が UI のどこにも無い。0件タブ無効化(F-13)実装。
- ✅ lint緑・`/legacy` 200(回帰なし)・test 48緑・build 成功・コンソールエラーなし。

Closes #32