### PR TITLE
1-3: 軽量化 Worker パイプライン基盤(prune/dedup)+ 軽量化サイドバー

### DIFF
--- a/app/(v2)/components/ui/Switch.module.scss
+++ b/app/(v2)/components/ui/Switch.module.scss
@@ -1,0 +1,26 @@
+.track {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-shrink: 0;
+  width: 36px;
+  height: 20px;
+  padding: 2px;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: var(--color-border-2);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.on {
+  justify-content: flex-end;
+  background: var(--color-accent);
+}
+
+.knob {
+  width: 16px;
+  height: 16px;
+  border-radius: var(--radius-pill);
+  background: #ffffff;
+}

--- a/app/(v2)/components/ui/Switch.tsx
+++ b/app/(v2)/components/ui/Switch.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import styles from "./Switch.module.scss";
+
+interface SwitchProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label: string;
+}
+
+/** Pill toggle (Figma): orange when on, grey when off, white knob. */
+export function Switch({ checked, onChange, label }: SwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      className={`${styles.track} ${checked ? styles.on : ""}`}
+      onClick={() => onChange(!checked)}
+    >
+      <span className={styles.knob} />
+    </button>
+  );
+}

--- a/app/(v2)/features/optimize/OptimizeCard.module.scss
+++ b/app/(v2)/features/optimize/OptimizeCard.module.scss
@@ -1,0 +1,68 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+  width: 100%;
+  padding: var(--space-18);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.sectionTitle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  width: 100%;
+}
+
+.icon {
+  display: inline-flex;
+  color: var(--color-accent);
+}
+
+.label {
+  flex: 1;
+  min-width: 0;
+  font-weight: 600;
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  color: var(--color-text);
+}
+
+.text {
+  margin: 0;
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  color: var(--color-text);
+}
+
+.dataArea {
+  display: flex;
+  gap: var(--space-8);
+  width: 100%;
+}
+
+.data {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  flex: 1;
+  min-width: 0;
+  padding: var(--space-12);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+}
+
+.dataLabel {
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-text-faint);
+}
+
+.dataValue {
+  font-weight: 600;
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  color: var(--color-text);
+}

--- a/app/(v2)/features/optimize/OptimizeSidebar.module.scss
+++ b/app/(v2)/features/optimize/OptimizeSidebar.module.scss
@@ -1,0 +1,14 @@
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-20);
+  width: 100%;
+}
+
+.heading {
+  margin: 0;
+  font-size: var(--font-size-16);
+  font-weight: 600;
+  line-height: 20px;
+  color: var(--color-text);
+}

--- a/app/(v2)/features/optimize/OptimizeSidebar.tsx
+++ b/app/(v2)/features/optimize/OptimizeSidebar.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useOptimizePipeline } from "./useOptimizePipeline";
+import { PruneDedupCard } from "./PruneDedupCard";
+import styles from "./OptimizeSidebar.module.scss";
+
+/**
+ * Optimize-mode sidebar (Figma node 73-1454). This issue (1-3) delivers the
+ * container + the prune/dedup section wired to the Worker pipeline. Texture /
+ * polygon sections and the save bar arrive in #35 / #36 / #37.
+ */
+export function OptimizeSidebar() {
+  useOptimizePipeline();
+
+  return (
+    <div className={styles.sidebar}>
+      <h2 className={styles.heading}>軽量化の設定はカスタマイズが可能です</h2>
+      <PruneDedupCard />
+    </div>
+  );
+}

--- a/app/(v2)/features/optimize/PruneDedupCard.tsx
+++ b/app/(v2)/features/optimize/PruneDedupCard.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useOptimizeStore } from "../../store/optimizeStore";
+import { Switch } from "../../components/ui/Switch";
+import { TrashIcon } from "../../icons";
+import styles from "./OptimizeCard.module.scss";
+
+/** 未使用データの削除 (prune/dedup) card. */
+export function PruneDedupCard() {
+  const enabled = useOptimizeStore((state) => state.settings.pruneDedup);
+  const setSettings = useOptimizeStore((state) => state.setSettings);
+  const status = useOptimizeStore((state) => state.status);
+  const unusedRemoved = useOptimizeStore((state) => state.result?.stats?.unusedRemoved);
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.sectionTitle}>
+        <span className={styles.icon}>
+          <TrashIcon size={14} />
+        </span>
+        <span className={styles.label}>未使用データの削除</span>
+        <Switch
+          checked={enabled}
+          onChange={(checked) => setSettings({ pruneDedup: checked })}
+          label="未使用データの削除"
+        />
+      </div>
+      <p className={styles.text}>使われていないデータを削除して軽量化します。</p>
+      <div className={styles.dataArea}>
+        <div className={styles.data}>
+          <span className={styles.dataLabel}>未使用データ</span>
+          <span className={styles.dataValue}>
+            {status === "estimating" ? "…" : (unusedRemoved ?? 0).toLocaleString()}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(v2)/features/optimize/useOptimizePipeline.ts
+++ b/app/(v2)/features/optimize/useOptimizePipeline.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect } from "react";
+import { useModelStore } from "../../store/modelStore";
+import { useOptimizeStore } from "../../store/optimizeStore";
+import { runPipeline, SupersededError } from "../../pipeline/pipelineClient";
+
+/**
+ * Runs the prune/dedup pipeline in the Worker whenever the optimize sidebar is
+ * mounted (and when the setting changes), storing the resulting bytes + stats.
+ * The Worker keeps the main thread responsive; stale runs are ignored via the
+ * generation token. (Estimate timing is refined in #34.)
+ */
+export function useOptimizePipeline() {
+  const bytes = useModelStore((state) => state.originalBytes);
+  const pruneDedup = useOptimizeStore((state) => state.settings.pruneDedup);
+  const setStatus = useOptimizeStore((state) => state.setStatus);
+  const setResult = useOptimizeStore((state) => state.setResult);
+
+  useEffect(() => {
+    if (!bytes) {
+      return;
+    }
+    let cancelled = false;
+    setStatus("estimating");
+    runPipeline(bytes, { pruneDedup })
+      .then((result) => {
+        if (cancelled) {
+          return;
+        }
+        setResult({
+          bytes: result.outBytes,
+          stats: {
+            afterBytes: result.stats.size,
+            polygons: result.stats.polygons,
+            textures: result.stats.textures,
+            unusedRemoved: result.stats.unusedRemoved,
+          },
+        });
+        setStatus("ready");
+      })
+      .catch((error) => {
+        if (cancelled || error instanceof SupersededError) {
+          return;
+        }
+        setStatus("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [bytes, pruneDedup, setStatus, setResult]);
+}

--- a/app/(v2)/features/preview/ModelWorkspace.tsx
+++ b/app/(v2)/features/preview/ModelWorkspace.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useModelStore } from "../../store/modelStore";
+import { useUiStore } from "../../store/uiStore";
 import { useThreeStage } from "../../viewer/useThreeStage";
 import { Stage } from "../../viewer/Stage";
 import { FileDropzone } from "../../components/FileDropzone";
 import { Copyright } from "../../components/Copyright";
 import { PreviewSidebar } from "./PreviewSidebar";
+import { OptimizeSidebar } from "../optimize/OptimizeSidebar";
 import styles from "../../styles/page.module.scss";
 
 /**
@@ -14,13 +16,20 @@ import styles from "../../styles/page.module.scss";
  */
 export function ModelWorkspace() {
   const bytes = useModelStore((state) => state.originalBytes);
+  const mode = useUiStore((state) => state.mode);
   const stage = useThreeStage(bytes);
 
   return (
     <>
       <aside className={styles.sidebar}>
-        <FileDropzone />
-        <PreviewSidebar stage={stage} />
+        {mode === "optimize" ? (
+          <OptimizeSidebar />
+        ) : (
+          <>
+            <FileDropzone />
+            <PreviewSidebar stage={stage} />
+          </>
+        )}
       </aside>
       <section className={styles.viewer} aria-label="3Dビュー">
         <Stage

--- a/app/(v2)/pipeline/optimize.worker.ts
+++ b/app/(v2)/pipeline/optimize.worker.ts
@@ -1,0 +1,83 @@
+// Optimization Worker: runs the non-destructive @gltf-transform pipeline off the
+// main thread. gltf-transform is dynamically imported (kept out of the main
+// bundle). Input is a copy of the original bytes; output is fresh bytes.
+import type { Document } from "@gltf-transform/core";
+import type { PipelineRequest, PipelineResponse } from "./types";
+
+const worker = self as unknown as Worker;
+const post = (message: PipelineResponse, transfer?: Transferable[]) =>
+  worker.postMessage(message, transfer ?? []);
+
+/** Total property count across the categories that prune can drop. */
+function propertyCount(document: Document): number {
+  const root = document.getRoot();
+  return (
+    root.listAccessors().length +
+    root.listTextures().length +
+    root.listMaterials().length +
+    root.listMeshes().length +
+    root.listSkins().length +
+    root.listNodes().length
+  );
+}
+
+/** Sum of triangles across all mesh primitives. */
+function countPolygons(document: Document): number {
+  let triangles = 0;
+  document
+    .getRoot()
+    .listMeshes()
+    .forEach((mesh) => {
+      mesh.listPrimitives().forEach((primitive) => {
+        const indices = primitive.getIndices();
+        const position = primitive.getAttribute("POSITION");
+        const count = indices ? indices.getCount() : position ? position.getCount() : 0;
+        triangles += count / 3;
+      });
+    });
+  return Math.round(triangles);
+}
+
+worker.onmessage = async (event: MessageEvent<PipelineRequest>) => {
+  const { id, bytes, settings } = event.data;
+  try {
+    const core = await import("@gltf-transform/core");
+    const functions = await import("@gltf-transform/functions");
+
+    const io = new core.WebIO();
+    const document = await io.readBinary(new Uint8Array(bytes));
+
+    // Preserve asset metadata (copyright) explicitly — §5.4.
+    const copyright = document.getRoot().getAsset().copyright;
+
+    const before = propertyCount(document);
+    if (settings.pruneDedup) {
+      await document.transform(functions.prune(), functions.dedup());
+    }
+    const after = propertyCount(document);
+
+    if (copyright) {
+      document.getRoot().getAsset().copyright = copyright;
+    }
+
+    const outArray = await io.writeBinary(document);
+    const outBytes = outArray.slice().buffer as ArrayBuffer;
+
+    post(
+      {
+        id,
+        type: "result",
+        outBytes,
+        stats: {
+          size: outBytes.byteLength,
+          polygons: countPolygons(document),
+          textures: document.getRoot().listTextures().length,
+          unusedRemoved: Math.max(0, before - after),
+        },
+      },
+      [outBytes]
+    );
+  } catch (error) {
+    post({ id, type: "error", message: (error as Error).message });
+  }
+};

--- a/app/(v2)/pipeline/pipelineClient.ts
+++ b/app/(v2)/pipeline/pipelineClient.ts
@@ -1,0 +1,58 @@
+import type { PipelineRequest, PipelineResponse, PipelineSettings, PipelineStats } from "./types";
+
+export interface PipelineResult {
+  outBytes: ArrayBuffer;
+  stats: PipelineStats;
+}
+
+/** Thrown when a newer request supersedes this one (generation token). */
+export class SupersededError extends Error {
+  constructor() {
+    super("superseded");
+    this.name = "SupersededError";
+  }
+}
+
+let worker: Worker | null = null;
+let latestId = 0;
+
+function getWorker(): Worker {
+  if (!worker) {
+    worker = new Worker(new URL("./optimize.worker.ts", import.meta.url));
+  }
+  return worker;
+}
+
+/**
+ * Run the optimize pipeline in the shared Worker. A generation token ensures
+ * only the most recent request resolves — older in-flight results are rejected
+ * with SupersededError so callers can ignore them. The original bytes are never
+ * transferred; a `slice(0)` copy is sent so `originalBytes` stays intact (§5.3).
+ */
+export function runPipeline(bytes: ArrayBuffer, settings: PipelineSettings): Promise<PipelineResult> {
+  const id = ++latestId;
+  const activeWorker = getWorker();
+  const copy = bytes.slice(0);
+
+  return new Promise<PipelineResult>((resolve, reject) => {
+    const onMessage = (event: MessageEvent<PipelineResponse>) => {
+      const data = event.data;
+      if (data.id !== id) {
+        return;
+      }
+      activeWorker.removeEventListener("message", onMessage);
+      if (id !== latestId) {
+        reject(new SupersededError());
+        return;
+      }
+      if (data.type === "result") {
+        resolve({ outBytes: data.outBytes, stats: data.stats });
+      } else {
+        reject(new Error(data.message));
+      }
+    };
+    activeWorker.addEventListener("message", onMessage);
+    const request: PipelineRequest = { id, bytes: copy, settings };
+    activeWorker.postMessage(request, [copy]);
+  });
+}

--- a/app/(v2)/pipeline/types.ts
+++ b/app/(v2)/pipeline/types.ts
@@ -1,0 +1,26 @@
+// Typed message contract between the main thread and the optimize Worker.
+// Kept free of store/zustand imports so the Worker bundle stays lean.
+
+export interface PipelineSettings {
+  /** prune unused data + dedup duplicates. */
+  pruneDedup: boolean;
+}
+
+export interface PipelineStats {
+  /** Byte length of the output glb. */
+  size: number;
+  polygons: number;
+  textures: number;
+  /** Number of unused properties removed by prune. */
+  unusedRemoved: number;
+}
+
+export interface PipelineRequest {
+  id: number;
+  bytes: ArrayBuffer;
+  settings: PipelineSettings;
+}
+
+export type PipelineResponse =
+  | { id: number; type: "result"; outBytes: ArrayBuffer; stats: PipelineStats }
+  | { id: number; type: "error"; message: string };

--- a/app/(v2)/store/optimizeStore.ts
+++ b/app/(v2)/store/optimizeStore.ts
@@ -30,6 +30,8 @@ export interface OptimizeResult {
   stats?: {
     afterBytes: number;
     polygons?: number;
+    textures?: number;
+    unusedRemoved?: number;
   };
 }
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,22 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  // @gltf-transform/core's entry pulls in NodeIO (node:fs). It only runs inside
+  // the optimize Web Worker, so stub the `node:` builtins for the browser
+  // bundle. (Validated in the #30 PoC.)
+  webpack: (config, { webpack }) => {
+    config.plugins.push(
+      new webpack.NormalModuleReplacementPlugin(/^node:/, (resource) => {
+        resource.request = resource.request.replace(/^node:/, "");
+      })
+    );
+    config.resolve.fallback = {
+      ...config.resolve.fallback,
+      fs: false,
+      path: false,
+      url: false,
+    };
+    return config;
+  },
+};
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "gltf-light",
       "version": "0.1.0",
       "dependencies": {
+        "@gltf-transform/core": "^4.4.1",
+        "@gltf-transform/functions": "^4.4.1",
         "@vercel/analytics": "^1.5.0",
         "next": "14.2.35",
         "react": "^18",
@@ -504,6 +506,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -951,6 +963,48 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@gltf-transform/core": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/core/-/core-4.4.1.tgz",
+      "integrity": "sha512-ygWWFOrj1HnfvBimHF1yHTY4abbeBjn3CvljijaWKoRLMRV/a8pWYQu9rfMFQhfpT5kYZTD5Mp+dizAXPbiTDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "property-graph": "^4.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/donmccurdy"
+      }
+    },
+    "node_modules/@gltf-transform/extensions": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/extensions/-/extensions-4.4.1.tgz",
+      "integrity": "sha512-dZZ9D/NdpNeJUmQKExtISYtd3W6OxU4njk8UI3IKm6j97uVskYQ24BNi2YP40uUpdWPiREsS/DhjNhWAbGU/1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@gltf-transform/core": "^4.4.1",
+        "ktx-parse": "^1.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/donmccurdy"
+      }
+    },
+    "node_modules/@gltf-transform/functions": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/functions/-/functions-4.4.1.tgz",
+      "integrity": "sha512-CAU6hczuRz7NIEtpn7BARuwVEwRawwIcGqmoMCaEwA4XC+CSUi3xptXuf2zDG/5AftFO7IeQxXl/56rDsck0GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@gltf-transform/core": "^4.4.1",
+        "@gltf-transform/extensions": "^4.4.1",
+        "ktx-parse": "^1.1.0",
+        "ndarray": "^1.0.19",
+        "ndarray-lanczos": "^0.3.0",
+        "ndarray-pixels": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/donmccurdy"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -985,6 +1039,471 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -1833,6 +2352,12 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/ndarray": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@types/ndarray/-/ndarray-1.0.14.tgz",
+      "integrity": "sha512-oANmFZMnFQvb219SSBIhI1Ih/r4CvHDOzkWyJS/XRqkMrGH5/kaPSA1hQhdIBzouaE+5KpE/f5ylI9cujmckQg==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.15.0",
@@ -2859,6 +3384,15 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true
     },
+    "node_modules/cwise-compiler": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
+      "integrity": "sha512-WXlK/m+Di8DMMcCjcWr4i+XzcQra9eCdXIJrgh4TUgh0pIS/yJduLxS9JgefsHJ/YVLdgPtXm9r62W92MvanEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uniq": "^1.0.0"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -3056,6 +3590,15 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dir-glob": {
@@ -4479,6 +5022,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/iota-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
+      "integrity": "sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA==",
+      "license": "MIT"
+    },
     "node_modules/is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -4564,6 +5113,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
@@ -5036,6 +5591,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/ktx-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-1.1.0.tgz",
+      "integrity": "sha512-mKp3y+FaYgR7mXWAbyyzpa/r1zDWeaunH+INJO4fou3hb45XuNSwar+7llrRyvpMWafxSIi99RNFJ05MHedaJQ==",
+      "license": "MIT"
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
@@ -5264,6 +5825,47 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/ndarray": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
+      "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iota-array": "^1.0.0",
+        "is-buffer": "^1.0.2"
+      }
+    },
+    "node_modules/ndarray-lanczos": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ndarray-lanczos/-/ndarray-lanczos-0.3.0.tgz",
+      "integrity": "sha512-5kBmmG3Zvyj77qxIAC4QFLKuYdDIBJwCG+DukT6jQHNa1Ft74/hPH1z5mbQXeHBt8yvGPBGVrr3wEOdJPYYZYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ndarray": "^1.0.11",
+        "ndarray": "^1.0.19"
+      }
+    },
+    "node_modules/ndarray-ops": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
+      "integrity": "sha512-BppWAFRjMYF7N/r6Ie51q6D4fs0iiGmeXIACKY66fLpnwIui3Wc3CXiD/30mgLbDjPpSLrsqcp3Z62+IcHZsDw==",
+      "license": "MIT",
+      "dependencies": {
+        "cwise-compiler": "^1.0.0"
+      }
+    },
+    "node_modules/ndarray-pixels": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ndarray-pixels/-/ndarray-pixels-5.0.1.tgz",
+      "integrity": "sha512-IBtrpefpqlI8SPDCGjXk4v5NV5z7r3JSuCbfuEEXaM0vrOJtNGgYUa4C3Lt5H+qWdYF4BCPVFsnXhNC7QvZwkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ndarray": "^1.0.14",
+        "ndarray": "^1.0.19",
+        "ndarray-ops": "^1.2.2",
+        "sharp": "^0.34.0"
+      }
     },
     "node_modules/next": {
       "version": "14.2.35",
@@ -5734,6 +6336,12 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-graph": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/property-graph/-/property-graph-4.1.0.tgz",
+      "integrity": "sha512-AvPcP7XECNWy4LGmFQ77k7un4lSKM4eS29PTvW4ck95uYeLxXPWJM7hLuBqK91FaHqCcgJvIUCuNJjjxKE7VKQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6122,10 +6730,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6163,6 +6771,50 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/shebang-command": {
@@ -6827,6 +7479,12 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.13.0.tgz",
       "integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==",
       "dev": true
+    },
+    "node_modules/uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==",
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@gltf-transform/core": "^4.4.1",
+    "@gltf-transform/functions": "^4.4.1",
     "@vercel/analytics": "^1.5.0",
     "next": "14.2.35",
     "react": "^18",


### PR DESCRIPTION
## 概要

非破壊パイプラインの中核(Worker で prune/dedup)を実装 (architecture §2.4/§5.3/§6 1-3)。あわせて、これまで暫定でプレビュー内容を表示していた**軽量化モードのサイドバーの器 + 未使用データ削除セクション**を Figma(node 73-1454)に沿って新設(ユーザー合意による前倒し)。

## 変更内容

- **`pipeline/optimize.worker.ts`**: Web Worker 内で `@gltf-transform/core`+`functions` を動的 import し prune/dedup を実行。asset copyright を保持し、新 bytes + 統計(size/polygons/textures/unusedRemoved)を返す。
- **`pipeline/pipelineClient.ts`**: 単一 Worker を再利用。**世代トークン**で最新リクエストのみ resolve(古い結果は `SupersededError`)。元 bytes は **`slice(0)` コピーを transfer** して detach から保護(§5.3)。
- **`next.config.mjs`**: `@gltf-transform/core` が含む `node:` を stub(#30 PoC の申し送り)。
- **軽量化サイドバー**(`features/optimize/`): 「軽量化の設定はカスタマイズが可能です」ヘッダー + **未使用データの削除カード**(Figma 75:457: ゴミ箱アイコン + トグル + 説明 + 「未使用データ N」)。トグルは `optimizeStore.settings.pruneDedup` に連動し、変更で再試算。
- **`ModelWorkspace`**: モードでサイドバーを分岐(optimize→OptimizeSidebar / preview→従来)。共通 `Switch` コンポーネント追加。
- テクスチャ/ポリゴンセクションと固定保存バーは #35/#36/#37。

## 動作確認 (QA / Playwright)

- ✅ 軽量化モードで専用サイドバー表示(ヘッダー + 未使用データ削除カード、トグルON、Figma一致)。
- ✅ **Worker が prune/dedup を実行**: test2.glb で未使用データ **4件**、test.glb で **9件**。トグルOFFで再試算し **0件**(設定→Worker連携)。
- ✅ **出力 glb が有効**(magic 'glTF'・images/materials 正常)、**サイズ減**(test2: 12,544,248→12,531,084B)。GLTFLoader 可読性・copyright 保持は #30 PoC で実証済みの同一ロジック(test2 は copyright 無しのため none→none で保持)。
- ✅ 実行は Worker(メインスレッド非ブロック、トグル操作は即応)。
- ✅ lint緑・`/legacy` 200・test 48緑・コンソールエラー0。

Closes #33