### PR TITLE
1-4: 軽量化タブの自動試算(ビュー非ロック)

### DIFF
--- a/app/(v2)/features/optimize/BeforeAfterSummary.module.scss
+++ b/app/(v2)/features/optimize/BeforeAfterSummary.module.scss
@@ -1,0 +1,56 @@
+.bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: sticky;
+  bottom: calc(-1 * var(--space-20));
+  // Push to the bottom, and break out of the sidebar's 20px padding so the bar
+  // spans the full width and sits flush with the sidebar edges.
+  margin: auto calc(-1 * var(--space-20)) calc(-1 * var(--space-20));
+  padding: var(--space-12);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.size {
+  display: flex;
+  flex-direction: column;
+}
+
+.delta {
+  font-weight: 600;
+  font-size: var(--font-size-16);
+  line-height: 20px;
+  color: var(--color-accent);
+}
+
+.sizes {
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  color: var(--color-text);
+  white-space: nowrap;
+}
+
+.placeholder {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-8);
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  color: var(--color-text-muted);
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--color-border-2);
+  border-top-color: var(--color-accent);
+  border-radius: var(--radius-pill);
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/app/(v2)/features/optimize/BeforeAfterSummary.tsx
+++ b/app/(v2)/features/optimize/BeforeAfterSummary.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useModelStore } from "../../store/modelStore";
+import { useOptimizeStore } from "../../store/optimizeStore";
+import { formatFileSize } from "../../lib/formatFileSize";
+import styles from "./BeforeAfterSummary.module.scss";
+
+/**
+ * Fixed summary bar at the bottom of the optimize sidebar (Figma save-box).
+ * Shows the auto-estimated size reduction; a placeholder while estimating.
+ * The save CTA is added in #37.
+ */
+export function BeforeAfterSummary() {
+  const originalSize = useModelStore((state) => state.meta?.size ?? 0);
+  const status = useOptimizeStore((state) => state.status);
+  const estimate = useOptimizeStore((state) => state.estimate);
+
+  const ready = status === "ready" && estimate != null;
+
+  return (
+    <div className={styles.bar}>
+      <div className={styles.size}>
+        {ready ? (
+          <>
+            <span className={styles.delta}>
+              {estimate.deltaPct > 0 ? `-${estimate.deltaPct}%` : "0%"}
+            </span>
+            <span className={styles.sizes}>
+              {formatFileSize(originalSize)} → {formatFileSize(estimate.afterBytes)}
+            </span>
+          </>
+        ) : (
+          <span className={styles.placeholder}>
+            <span className={styles.spinner} aria-hidden="true" />
+            計算中…
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(v2)/features/optimize/OptimizeSidebar.module.scss
+++ b/app/(v2)/features/optimize/OptimizeSidebar.module.scss
@@ -3,6 +3,7 @@
   flex-direction: column;
   gap: var(--space-20);
   width: 100%;
+  min-height: 100%;
 }
 
 .heading {

--- a/app/(v2)/features/optimize/OptimizeSidebar.tsx
+++ b/app/(v2)/features/optimize/OptimizeSidebar.tsx
@@ -2,6 +2,7 @@
 
 import { useOptimizePipeline } from "./useOptimizePipeline";
 import { PruneDedupCard } from "./PruneDedupCard";
+import { BeforeAfterSummary } from "./BeforeAfterSummary";
 import styles from "./OptimizeSidebar.module.scss";
 
 /**
@@ -16,6 +17,7 @@ export function OptimizeSidebar() {
     <div className={styles.sidebar}>
       <h2 className={styles.heading}>軽量化の設定はカスタマイズが可能です</h2>
       <PruneDedupCard />
+      <BeforeAfterSummary />
     </div>
   );
 }

--- a/app/(v2)/features/optimize/useOptimizePipeline.ts
+++ b/app/(v2)/features/optimize/useOptimizePipeline.ts
@@ -4,18 +4,31 @@ import { useEffect } from "react";
 import { useModelStore } from "../../store/modelStore";
 import { useOptimizeStore } from "../../store/optimizeStore";
 import { runPipeline, SupersededError } from "../../pipeline/pipelineClient";
+import { computeEstimate } from "../../pipeline/estimate";
+
+/** Defer work to browser idle time so the 3D render/interaction stays first. */
+function whenIdle(callback: () => void): () => void {
+  if (typeof requestIdleCallback === "function") {
+    const handle = requestIdleCallback(callback, { timeout: 500 });
+    return () => cancelIdleCallback(handle);
+  }
+  const handle = window.setTimeout(callback, 200);
+  return () => window.clearTimeout(handle);
+}
 
 /**
- * Runs the prune/dedup pipeline in the Worker whenever the optimize sidebar is
- * mounted (and when the setting changes), storing the resulting bytes + stats.
- * The Worker keeps the main thread responsive; stale runs are ignored via the
- * generation token. (Estimate timing is refined in #34.)
+ * Auto-estimates the optimize result whenever the optimize sidebar is mounted
+ * (and when a setting changes). The Worker keeps the main thread responsive and
+ * the run is deferred to idle time so the 3D view renders/interacts first (F-17
+ * / §5.2). Stale runs are ignored via the generation token.
  */
 export function useOptimizePipeline() {
   const bytes = useModelStore((state) => state.originalBytes);
+  const originalSize = useModelStore((state) => state.meta?.size ?? 0);
   const pruneDedup = useOptimizeStore((state) => state.settings.pruneDedup);
   const setStatus = useOptimizeStore((state) => state.setStatus);
   const setResult = useOptimizeStore((state) => state.setResult);
+  const setEstimate = useOptimizeStore((state) => state.setEstimate);
 
   useEffect(() => {
     if (!bytes) {
@@ -23,30 +36,37 @@ export function useOptimizePipeline() {
     }
     let cancelled = false;
     setStatus("estimating");
-    runPipeline(bytes, { pruneDedup })
-      .then((result) => {
-        if (cancelled) {
-          return;
-        }
-        setResult({
-          bytes: result.outBytes,
-          stats: {
-            afterBytes: result.stats.size,
-            polygons: result.stats.polygons,
-            textures: result.stats.textures,
-            unusedRemoved: result.stats.unusedRemoved,
-          },
+    setEstimate(null);
+
+    const cancelIdle = whenIdle(() => {
+      runPipeline(bytes, { pruneDedup })
+        .then((result) => {
+          if (cancelled) {
+            return;
+          }
+          setResult({
+            bytes: result.outBytes,
+            stats: {
+              afterBytes: result.stats.size,
+              polygons: result.stats.polygons,
+              textures: result.stats.textures,
+              unusedRemoved: result.stats.unusedRemoved,
+            },
+          });
+          setEstimate(computeEstimate(originalSize, result.stats.size));
+          setStatus("ready");
+        })
+        .catch((error) => {
+          if (cancelled || error instanceof SupersededError) {
+            return;
+          }
+          setStatus("error");
         });
-        setStatus("ready");
-      })
-      .catch((error) => {
-        if (cancelled || error instanceof SupersededError) {
-          return;
-        }
-        setStatus("error");
-      });
+    });
+
     return () => {
       cancelled = true;
+      cancelIdle();
     };
-  }, [bytes, pruneDedup, setStatus, setResult]);
+  }, [bytes, originalSize, pruneDedup, setStatus, setResult, setEstimate]);
 }

--- a/app/(v2)/pipeline/estimate.ts
+++ b/app/(v2)/pipeline/estimate.ts
@@ -1,0 +1,12 @@
+export interface Estimate {
+  /** Output byte length. */
+  afterBytes: number;
+  /** Size reduction vs the original, as a whole percentage (e.g. 67 → "-67%"). */
+  deltaPct: number;
+}
+
+/** Compute the size-reduction estimate from the original and optimized sizes. */
+export function computeEstimate(beforeBytes: number, afterBytes: number): Estimate {
+  const deltaPct = beforeBytes > 0 ? Math.round(((beforeBytes - afterBytes) / beforeBytes) * 100) : 0;
+  return { afterBytes, deltaPct };
+}

--- a/app/(v2)/store/optimizeStore.ts
+++ b/app/(v2)/store/optimizeStore.ts
@@ -18,10 +18,10 @@ export interface OptimizeSettings {
   };
 }
 
-/** F-17 auto-estimation result (placeholder → numbers). */
+/** F-17 auto-estimation result. `null` in the store means "not estimated yet". */
 export interface OptimizeEstimate {
-  afterBytes?: number;
-  deltaPct?: number;
+  afterBytes: number;
+  deltaPct: number;
 }
 
 /** Result of a transform run. `bytes` are new — the original is never touched. */


### PR DESCRIPTION
## 概要

軽量化タブを開いた時点で prune/dedup 効果を自動試算し「-XX%」を表示する (PRD F-17, architecture §5.2)。3D 描画・操作を最優先にするため試算開始を idle まで後ろ倒し。

## 変更内容

- **`pipeline/estimate.ts`**: 元サイズ/出力サイズから削減率を算出。
- **`useOptimizePipeline`**: 試算開始を **`requestIdleCallback`** で後ろ倒し(3D 描画/操作を優先)。Worker で実行しメインスレッド非ブロック。**世代トークン**で古い結果を破棄。試算値(`estimate`)を store に保存。
- **`BeforeAfterSummary`**: サイドバー下部の**固定サマリバー**(Figma save-box 80:1040)。試算中は **「計算中…」スピナー**、完了で **「-XX%」+「before → after」**。保存ボタンは #37。
- `optimizeStore.OptimizeEstimate` を必須フィールド化。

## 動作確認 (QA / Playwright)

- ✅ 軽量化タブを開くと自動試算 → **「-25%」/「75.8KB → 57.0KB」**(test.glb)を下部固定バーに表示。test2 は prune のみで約 0%(→ テクスチャ縮小 #35 で実効化)。
- ✅ 試算中に **「計算中…」プレースホルダ**が表示される(切替直後に確認)。
- ✅ **試算中も 3D 描画・カメラ操作が途切れない**(ドラッグ中もレンダリングループ継続=フリーズなし)。
- ✅ プレビュー↔軽量化を往復しても不整合なし(世代トークン + effect の cancel)。
- ✅ lint緑・`/legacy` 200・test 48緑・コンソールエラー0。

Closes #34