### PR TITLE
1-5: テクスチャ一括縮小(全マップ対象)

### DIFF
--- a/app/(v2)/features/optimize/OptimizeSidebar.tsx
+++ b/app/(v2)/features/optimize/OptimizeSidebar.tsx
@@ -2,6 +2,7 @@
 
 import { useOptimizePipeline } from "./useOptimizePipeline";
 import { PruneDedupCard } from "./PruneDedupCard";
+import { TextureOptimizeCard } from "./TextureOptimizeCard";
 import { BeforeAfterSummary } from "./BeforeAfterSummary";
 import styles from "./OptimizeSidebar.module.scss";
 
@@ -17,6 +18,7 @@ export function OptimizeSidebar() {
     <div className={styles.sidebar}>
       <h2 className={styles.heading}>軽量化の設定はカスタマイズが可能です</h2>
       <PruneDedupCard />
+      <TextureOptimizeCard />
       <BeforeAfterSummary />
     </div>
   );

--- a/app/(v2)/features/optimize/TextureOptimizeCard.module.scss
+++ b/app/(v2)/features/optimize/TextureOptimizeCard.module.scss
@@ -1,0 +1,59 @@
+.note {
+  margin: 0;
+  font-weight: 600;
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-highlight);
+}
+
+.chips {
+  display: flex;
+  gap: var(--space-8);
+  width: 100%;
+}
+
+.chip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 1;
+  min-width: 0;
+  padding: var(--space-8);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+
+  &:hover:not(.chipActive) {
+    border-color: var(--color-border-2);
+  }
+}
+
+.chipActive {
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
+.chipValue {
+  font-weight: 600;
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  color: var(--color-text);
+
+  .chipActive & {
+    color: var(--color-accent);
+  }
+}
+
+.chipSub {
+  font-size: var(--font-size-9);
+  line-height: 12px;
+  color: var(--color-text-faint);
+
+  .chipActive & {
+    color: var(--color-accent);
+  }
+}

--- a/app/(v2)/features/optimize/TextureOptimizeCard.tsx
+++ b/app/(v2)/features/optimize/TextureOptimizeCard.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { useModelStore } from "../../store/modelStore";
+import { useOptimizeStore } from "../../store/optimizeStore";
+import { Switch } from "../../components/ui/Switch";
+import { ImageIcon } from "../../icons";
+import card from "./OptimizeCard.module.scss";
+import styles from "./TextureOptimizeCard.module.scss";
+
+type Resolution = 512 | 1024 | 2048;
+
+const OPTIONS: { value: Resolution; sub: string }[] = [
+  { value: 512, sub: "最軽量" },
+  { value: 1024, sub: "おすすめ" },
+  { value: 2048, sub: "高品質" },
+];
+
+/** テクスチャの最適化: bulk downscale of every texture map to a chosen max edge. */
+export function TextureOptimizeCard() {
+  const maxTextureSize = useModelStore((state) => state.meta?.maxTextureSize);
+  const textureMaxSize = useOptimizeStore((state) => state.settings.textureMaxSize);
+  const setSettings = useOptimizeStore((state) => state.setSettings);
+
+  const enabled = textureMaxSize !== "off";
+  const [lastResolution, setLastResolution] = useState<Resolution>(
+    typeof textureMaxSize === "number" ? textureMaxSize : 1024
+  );
+  const selected = enabled ? (textureMaxSize as Resolution) : lastResolution;
+
+  const toggle = (on: boolean) => setSettings({ textureMaxSize: on ? lastResolution : "off" });
+  const selectResolution = (value: Resolution) => {
+    setLastResolution(value);
+    setSettings({ textureMaxSize: value });
+  };
+
+  return (
+    <div className={card.card}>
+      <div className={card.sectionTitle}>
+        <span className={card.icon}>
+          <ImageIcon size={14} />
+        </span>
+        <span className={card.label}>テクスチャの最適化</span>
+        <Switch checked={enabled} onChange={toggle} label="テクスチャの最適化" />
+      </div>
+      <p className={card.text}>最大解像度を選ぶだけで、すべての画像をまとめて縮小します。</p>
+      <p className={styles.note}>※指定解像度を超えるもののみ調整します</p>
+
+      {enabled && (
+        <>
+          {maxTextureSize != null && (
+            <div className={card.dataArea}>
+              <div className={card.data}>
+                <span className={card.dataLabel}>現在の最大解像度</span>
+                <span className={card.dataValue}>{maxTextureSize.toLocaleString()}</span>
+              </div>
+            </div>
+          )}
+          <div className={styles.chips} role="group" aria-label="最大解像度">
+            {OPTIONS.map(({ value, sub }) => (
+              <button
+                key={value}
+                type="button"
+                className={`${styles.chip} ${selected === value ? styles.chipActive : ""}`}
+                aria-pressed={selected === value}
+                onClick={() => selectResolution(value)}
+              >
+                <span className={styles.chipValue}>{value}</span>
+                <span className={styles.chipSub}>{sub}</span>
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/(v2)/features/optimize/useOptimizePipeline.ts
+++ b/app/(v2)/features/optimize/useOptimizePipeline.ts
@@ -26,6 +26,7 @@ export function useOptimizePipeline() {
   const bytes = useModelStore((state) => state.originalBytes);
   const originalSize = useModelStore((state) => state.meta?.size ?? 0);
   const pruneDedup = useOptimizeStore((state) => state.settings.pruneDedup);
+  const textureMaxSize = useOptimizeStore((state) => state.settings.textureMaxSize);
   const setStatus = useOptimizeStore((state) => state.setStatus);
   const setResult = useOptimizeStore((state) => state.setResult);
   const setEstimate = useOptimizeStore((state) => state.setEstimate);
@@ -39,7 +40,7 @@ export function useOptimizePipeline() {
     setEstimate(null);
 
     const cancelIdle = whenIdle(() => {
-      runPipeline(bytes, { pruneDedup })
+      runPipeline(bytes, { pruneDedup, textureMaxSize })
         .then((result) => {
           if (cancelled) {
             return;
@@ -68,5 +69,5 @@ export function useOptimizePipeline() {
       cancelled = true;
       cancelIdle();
     };
-  }, [bytes, originalSize, pruneDedup, setStatus, setResult, setEstimate]);
+  }, [bytes, originalSize, pruneDedup, textureMaxSize, setStatus, setResult, setEstimate]);
 }

--- a/app/(v2)/icons/index.tsx
+++ b/app/(v2)/icons/index.tsx
@@ -71,6 +71,9 @@ export const FilmIcon = (props: IconProps) => (
 export const LayersIcon = (props: IconProps) => (
   <Icon {...props}><path d="M12 2 2 7l10 5 10-5z" /><path d="M2 17l10 5 10-5" /><path d="M2 12l10 5 10-5" /></Icon>
 );
+export const ImageIcon = (props: IconProps) => (
+  <Icon {...props}><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="8.5" cy="8.5" r="1.5" /><path d="M21 15l-5-5L5 21" /></Icon>
+);
 export const MemoIcon = (props: IconProps) => (
   <Icon {...props}><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" /><path d="M8 13h8" /><path d="M8 17h5" /></Icon>
 );

--- a/app/(v2)/pipeline/optimize.worker.ts
+++ b/app/(v2)/pipeline/optimize.worker.ts
@@ -21,6 +21,41 @@ function propertyCount(document: Document): number {
   );
 }
 
+/** Downscale every texture whose longest edge exceeds `maxSize`, in place. */
+async function downscaleTextures(document: Document, maxSize: number): Promise<void> {
+  for (const texture of document.getRoot().listTextures()) {
+    const image = texture.getImage();
+    const size = texture.getSize();
+    const mimeType = texture.getMimeType() || "image/png";
+    if (!image || !size) {
+      continue;
+    }
+    const [width, height] = size;
+    const longest = Math.max(width, height);
+    if (longest <= maxSize) {
+      continue;
+    }
+    const scale = maxSize / longest;
+    const targetWidth = Math.max(1, Math.round(width * scale));
+    const targetHeight = Math.max(1, Math.round(height * scale));
+
+    const bitmap = await createImageBitmap(new Blob([image as BlobPart], { type: mimeType }));
+    const canvas = new OffscreenCanvas(targetWidth, targetHeight);
+    const context = canvas.getContext("2d");
+    if (!context) {
+      bitmap.close();
+      continue;
+    }
+    context.drawImage(bitmap, 0, 0, targetWidth, targetHeight);
+    bitmap.close();
+
+    const blob = await canvas.convertToBlob(
+      mimeType === "image/jpeg" ? { type: "image/jpeg", quality: 0.85 } : { type: mimeType }
+    );
+    texture.setImage(new Uint8Array(await blob.arrayBuffer()));
+  }
+}
+
 /** Sum of triangles across all mesh primitives. */
 function countPolygons(document: Document): number {
   let triangles = 0;
@@ -55,6 +90,14 @@ worker.onmessage = async (event: MessageEvent<PipelineRequest>) => {
       await document.transform(functions.prune(), functions.dedup());
     }
     const after = propertyCount(document);
+
+    // Downscale all texture maps to the chosen max edge via OffscreenCanvas
+    // (the #30 fallback — reliable in-browser, keeps the original encoding so a
+    // JPEG stays a JPEG with no PNG bloat). Only textures larger than the box
+    // are touched.
+    if (typeof settings.textureMaxSize === "number") {
+      await downscaleTextures(document, settings.textureMaxSize);
+    }
 
     if (copyright) {
       document.getRoot().getAsset().copyright = copyright;

--- a/app/(v2)/pipeline/types.ts
+++ b/app/(v2)/pipeline/types.ts
@@ -1,9 +1,14 @@
 // Typed message contract between the main thread and the optimize Worker.
 // Kept free of store/zustand imports so the Worker bundle stays lean.
 
+/** Max texture edge length; `"off"` disables texture downscaling. */
+export type TextureMaxSize = 2048 | 1024 | 512 | "off";
+
 export interface PipelineSettings {
   /** prune unused data + dedup duplicates. */
   pruneDedup: boolean;
+  /** Downscale every texture map to this max edge; `"off"` keeps them. */
+  textureMaxSize: TextureMaxSize;
 }
 
 export interface PipelineStats {

--- a/app/(v2)/store/modelStore.ts
+++ b/app/(v2)/store/modelStore.ts
@@ -13,6 +13,8 @@ export interface ModelMeta {
   readonly copyright?: string;
   readonly polygons?: number;
   readonly textures?: readonly ModelTextureMeta[];
+  /** Largest texture edge (px) in the original model. */
+  readonly maxTextureSize?: number;
 }
 
 export interface ModelTextureMeta {

--- a/app/(v2)/styles/tokens.scss
+++ b/app/(v2)/styles/tokens.scss
@@ -6,6 +6,7 @@
   // Brand / accent (role-stable across themes)
   --color-accent: #ff5b1d; // Figma color/orange — active tab, section icons, CTA
   --color-accent-strong: #ed4f14; // hover / pressed
+  --color-accent-soft: #ffece4; // tinted accent surface (selected chip)
   --color-on-accent: #ffffff; // text/icon on an accent fill
   --color-highlight: #2f6bff; // Figma color/blue-8 — upload icon, notes, focus
   --color-highlight-soft: #eaf0ff; // Figma color/blue-2 — selected row background
@@ -57,6 +58,7 @@
 [data-app="v2"][data-theme="dark"] {
   --color-accent: #ff7a52;
   --color-accent-strong: #ff6a3d;
+  --color-accent-soft: #3a2a22;
   --color-highlight: #6f9bff;
 
   --color-bg: #1b1a18;

--- a/app/(v2)/viewer/useThreeStage.ts
+++ b/app/(v2)/viewer/useThreeStage.ts
@@ -375,13 +375,20 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
         model.traverse((object) => stage.objectsByUuid.set(object.uuid, object));
 
         // Extract serializable model data for the preview UI.
+        stage.materials = new Map();
+        const materialInfos = collectMaterials(model, stage.materials, parseGlbTextureSizes(bytes));
+        const maxTextureSize = materialInfos.reduce(
+          (max, material) =>
+            material.textures.reduce((inner, texture) => Math.max(inner, texture.width, texture.height), max),
+          0
+        );
         const existingMeta = useModelStore.getState().meta;
         setMeta({
           ...(existingMeta ?? { name: "", size: bytes.byteLength }),
           polygons: countTriangles(model),
+          maxTextureSize: maxTextureSize || undefined,
         });
-        stage.materials = new Map();
-        setMaterials(collectMaterials(model, stage.materials, parseGlbTextureSizes(bytes)));
+        setMaterials(materialInfos);
         setMeshTree(buildMeshTree(model));
 
         // Fit camera to the model bounds.


### PR DESCRIPTION
## 概要

最大解像度を選ぶだけで**全テクスチャマップ(baseColor 含む)**を一括縮小 (PRD F-4)。旧実装の baseColor 限定・非圧縮化(PNG化)バグを一掃 (architecture §6 1-5)。

## 変更内容

- **Worker(`optimize.worker.ts`)**: `textureCompress` は実モデルの実テクスチャを縮小できなかったため、**#30 PoC 検証済みの OffscreenCanvas + createImageBitmap 自前リサイズ**に切替。`document.getRoot().listTextures()` の**全テクスチャ**(baseColor / normal / roughness / metalness / emissive 等)を対象に、長辺が指定解像度を超える場合のみ縮小(拡大しない)。**元のエンコード形式を維持**(JPEG→JPEG で PNG 化肥大なし)。prune/dedup の後に適用。
- **`TextureOptimizeCard`**: 画像アイコン + トグル + 解像度チップ(512 最軽量 / 1024 おすすめ / 2048 高品質) + 「現在の最大解像度」。トグルOFFで設定を畳む(Figma 75-760)。`optimizeStore.textureMaxSize` に連動し、変更で自動試算が再実行(非破壊)。
- `useThreeStage` が元モデルの最大テクスチャ解像度を `modelStore.meta` に反映。`ImageIcon` / `--color-accent-soft` 追加。
- `PipelineSettings.textureMaxSize` を追加。

## 動作確認 (QA / Playwright, test2.glb: 2048/1024混在・JPEG+PNG)

- ✅ 解像度で縮小率が変化: **1024 → -15%(12.0MB→10.2MB)** / **512 → -50%(12.0MB→6.0MB)**。
- ✅ **出力glbの全16画像が指定解像度以下**(512選択時 maxDim=512)を実測。**baseColor を含む全マップ**が対象(マテリアル別 baseColor を実測: Skin/Outfit系 1024+→512、Eye 128は拡大なし)。
- ✅ **JPEG は JPEG のまま**(出力 mimeType に image/jpeg と image/png 両方=形式維持、**PNG化肥大なし**)。
- ✅ 全出力画像が `createImageBitmap` でデコード可能(見た目破綻なし)。**3Dビューへの反映(Before/After 目視)は #37**。
- ✅ チップ/トグル変更で何度でも再試算(非破壊)。トグルOFFでチップ非表示。
- ✅ lint緑・`/legacy` 200・test 48緑・コンソールエラー0。

Closes #35