### PR TITLE
1-6: ポリゴン削減の gltf-transform simplify 載せ替え(既定オフ)

### DIFF
--- a/app/(v2)/features/optimize/OptimizeSidebar.tsx
+++ b/app/(v2)/features/optimize/OptimizeSidebar.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import type { StageController } from "../../viewer/useThreeStage";
 import { useOptimizePipeline } from "./useOptimizePipeline";
 import { PruneDedupCard } from "./PruneDedupCard";
 import { TextureOptimizeCard } from "./TextureOptimizeCard";
+import { PolygonReduceCard } from "./PolygonReduceCard";
 import { BeforeAfterSummary } from "./BeforeAfterSummary";
 import styles from "./OptimizeSidebar.module.scss";
 
@@ -11,7 +13,7 @@ import styles from "./OptimizeSidebar.module.scss";
  * container + the prune/dedup section wired to the Worker pipeline. Texture /
  * polygon sections and the save bar arrive in #35 / #36 / #37.
  */
-export function OptimizeSidebar() {
+export function OptimizeSidebar({ stage }: { stage: StageController }) {
   useOptimizePipeline();
 
   return (
@@ -19,6 +21,7 @@ export function OptimizeSidebar() {
       <h2 className={styles.heading}>軽量化の設定はカスタマイズが可能です</h2>
       <PruneDedupCard />
       <TextureOptimizeCard />
+      <PolygonReduceCard stage={stage} />
       <BeforeAfterSummary />
     </div>
   );

--- a/app/(v2)/features/optimize/PolygonReduceCard.module.scss
+++ b/app/(v2)/features/optimize/PolygonReduceCard.module.scss
@@ -1,0 +1,121 @@
+.warning {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin: 0;
+  font-weight: 600;
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-highlight);
+}
+
+.warningStrong {
+  color: var(--color-accent);
+
+  svg {
+    flex-shrink: 0;
+  }
+}
+
+.slider {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+.sliderHead {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-text-muted);
+}
+
+.value {
+  font-weight: 600;
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.bar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 16px;
+}
+
+.fill {
+  position: absolute;
+  left: 0;
+  height: 6px;
+  border-radius: var(--radius-sm);
+  background: var(--color-highlight);
+}
+
+.bar::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 6px;
+  border-radius: var(--radius-sm);
+  background: var(--color-border);
+}
+
+.knob {
+  position: absolute;
+  z-index: 1;
+  width: 11.2px;
+  height: 11.2px;
+  transform: translateX(-50%);
+  border: 2px solid var(--color-surface);
+  border-radius: var(--radius-pill);
+  background: var(--color-highlight);
+  pointer-events: none;
+}
+
+.input {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 16px;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.wireframeToggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid var(--color-text-faint);
+  border-radius: 3px;
+  background: var(--color-surface);
+  color: transparent;
+}
+
+.checkOn {
+  border-color: var(--color-highlight);
+  background: var(--color-highlight);
+  color: var(--color-on-accent);
+}
+
+.wireframeLabel {
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  color: var(--color-text-muted);
+}

--- a/app/(v2)/features/optimize/PolygonReduceCard.tsx
+++ b/app/(v2)/features/optimize/PolygonReduceCard.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { StageController } from "../../viewer/useThreeStage";
+import { useModelStore } from "../../store/modelStore";
+import { useOptimizeStore } from "../../store/optimizeStore";
+import { Switch } from "../../components/ui/Switch";
+import { LayersIcon, CheckIcon, AlertIcon } from "../../icons";
+import card from "./OptimizeCard.module.scss";
+import styles from "./PolygonReduceCard.module.scss";
+
+const MAX_REDUCTION = 90; // %
+
+/** ポリゴンの削減: meshoptimizer simplify. OFF by default; explicit action only. */
+export function PolygonReduceCard({ stage }: { stage: StageController }) {
+  const originalPolygons = useModelStore((state) => state.meta?.polygons);
+  const reduce = useOptimizeStore((state) => state.settings.reduce);
+  const setSettings = useOptimizeStore((state) => state.setSettings);
+  const resultPolygons = useOptimizeStore((state) => state.result?.stats?.polygons);
+  const [wireframe, setWireframe] = useState(false);
+
+  const enabled = reduce.enabled;
+  const reductionPct = Math.round((1 - reduce.ratio) * 100);
+  const trackPct = (reductionPct / MAX_REDUCTION) * 100;
+
+  // Always clear the wireframe overlay when the card unmounts.
+  useEffect(() => () => stage.setWireframe(false), [stage]);
+  // Turn the wireframe off if reduction is disabled.
+  useEffect(() => {
+    if (!enabled && wireframe) {
+      setWireframe(false);
+      stage.setWireframe(false);
+    }
+  }, [enabled, wireframe, stage]);
+
+  const toggleEnabled = (on: boolean) => setSettings({ reduce: { ...reduce, enabled: on } });
+  const setReduction = (pct: number) => setSettings({ reduce: { ...reduce, ratio: 1 - pct / 100 } });
+  const toggleWireframe = () => {
+    const next = !wireframe;
+    setWireframe(next);
+    stage.setWireframe(next);
+  };
+
+  return (
+    <div className={card.card}>
+      <div className={card.sectionTitle}>
+        <span className={card.icon}>
+          <LayersIcon size={14} />
+        </span>
+        <span className={card.label}>ポリゴンの削減</span>
+        <Switch checked={enabled} onChange={toggleEnabled} label="ポリゴンの削減" />
+      </div>
+      <p className={card.text}>面の数を減らして軽くします（既定はオフ）。</p>
+      <p className={`${styles.warning} ${stage.hasSkin ? styles.warningStrong : ""}`}>
+        {stage.hasSkin && <AlertIcon size={12} />}
+        {stage.hasSkin
+          ? "スキン／アニメーション付きモデルは形が崩れやすいためご注意ください"
+          : "※形やアニメーションが崩れる場合があります"}
+      </p>
+
+      {enabled && (
+        <>
+          <div className={styles.slider}>
+            <span className={styles.sliderHead}>
+              <span>削減率</span>
+              <span className={styles.value}>{reductionPct}%</span>
+            </span>
+            <div className={styles.bar}>
+              <div className={styles.fill} style={{ width: `${trackPct}%` }} />
+              <span className={styles.knob} style={{ left: `${trackPct}%` }} />
+              <input
+                type="range"
+                className={styles.input}
+                min={0}
+                max={MAX_REDUCTION}
+                step={5}
+                value={reductionPct}
+                onChange={(event) => setReduction(Number(event.target.value))}
+                aria-label="削減率"
+              />
+            </div>
+          </div>
+
+          <button
+            type="button"
+            className={styles.wireframeToggle}
+            aria-pressed={wireframe}
+            onClick={toggleWireframe}
+          >
+            <span className={`${styles.check} ${wireframe ? styles.checkOn : ""}`} aria-hidden="true">
+              {wireframe && <CheckIcon size={9} />}
+            </span>
+            <span className={styles.wireframeLabel}>ワイヤーフレームで確認</span>
+          </button>
+
+          <div className={card.dataArea}>
+            <div className={card.data}>
+              <span className={card.dataLabel}>ポリゴン数</span>
+              <span className={card.dataValue}>
+                {(resultPolygons ?? originalPolygons ?? 0).toLocaleString()}
+              </span>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/(v2)/features/optimize/useOptimizePipeline.ts
+++ b/app/(v2)/features/optimize/useOptimizePipeline.ts
@@ -27,6 +27,8 @@ export function useOptimizePipeline() {
   const originalSize = useModelStore((state) => state.meta?.size ?? 0);
   const pruneDedup = useOptimizeStore((state) => state.settings.pruneDedup);
   const textureMaxSize = useOptimizeStore((state) => state.settings.textureMaxSize);
+  const reduceEnabled = useOptimizeStore((state) => state.settings.reduce.enabled);
+  const reduceRatio = useOptimizeStore((state) => state.settings.reduce.ratio);
   const setStatus = useOptimizeStore((state) => state.setStatus);
   const setResult = useOptimizeStore((state) => state.setResult);
   const setEstimate = useOptimizeStore((state) => state.setEstimate);
@@ -40,7 +42,11 @@ export function useOptimizePipeline() {
     setEstimate(null);
 
     const cancelIdle = whenIdle(() => {
-      runPipeline(bytes, { pruneDedup, textureMaxSize })
+      runPipeline(bytes, {
+        pruneDedup,
+        textureMaxSize,
+        reduce: { enabled: reduceEnabled, ratio: reduceRatio },
+      })
         .then((result) => {
           if (cancelled) {
             return;
@@ -69,5 +75,15 @@ export function useOptimizePipeline() {
       cancelled = true;
       cancelIdle();
     };
-  }, [bytes, originalSize, pruneDedup, textureMaxSize, setStatus, setResult, setEstimate]);
+  }, [
+    bytes,
+    originalSize,
+    pruneDedup,
+    textureMaxSize,
+    reduceEnabled,
+    reduceRatio,
+    setStatus,
+    setResult,
+    setEstimate,
+  ]);
 }

--- a/app/(v2)/features/preview/ModelWorkspace.tsx
+++ b/app/(v2)/features/preview/ModelWorkspace.tsx
@@ -23,7 +23,7 @@ export function ModelWorkspace() {
     <>
       <aside className={styles.sidebar}>
         {mode === "optimize" ? (
-          <OptimizeSidebar />
+          <OptimizeSidebar stage={stage} />
         ) : (
           <>
             <FileDropzone />

--- a/app/(v2)/pipeline/optimize.worker.ts
+++ b/app/(v2)/pipeline/optimize.worker.ts
@@ -91,6 +91,21 @@ worker.onmessage = async (event: MessageEvent<PipelineRequest>) => {
     }
     const after = propertyCount(document);
 
+    // Polygon reduction (meshoptimizer simplify) — only when explicitly enabled.
+    if (settings.reduce.enabled) {
+      const meshopt = await import("meshoptimizer");
+      await meshopt.MeshoptSimplifier.ready;
+      await document.transform(
+        functions.simplify({
+          simplifier: meshopt.MeshoptSimplifier,
+          ratio: settings.reduce.ratio,
+          // Looser error tolerance so the slider ratio can actually be reached
+          // (a tight bound stops simplification early on dense/skinned meshes).
+          error: 0.05,
+        })
+      );
+    }
+
     // Downscale all texture maps to the chosen max edge via OffscreenCanvas
     // (the #30 fallback — reliable in-browser, keeps the original encoding so a
     // JPEG stays a JPEG with no PNG bloat). Only textures larger than the box

--- a/app/(v2)/pipeline/types.ts
+++ b/app/(v2)/pipeline/types.ts
@@ -9,6 +9,12 @@ export interface PipelineSettings {
   pruneDedup: boolean;
   /** Downscale every texture map to this max edge; `"off"` keeps them. */
   textureMaxSize: TextureMaxSize;
+  /** Polygon reduction (meshoptimizer simplify) — OFF by default. */
+  reduce: {
+    enabled: boolean;
+    /** Target ratio of triangles to keep (0–1). */
+    ratio: number;
+  };
 }
 
 export interface PipelineStats {

--- a/app/(v2)/viewer/useThreeStage.ts
+++ b/app/(v2)/viewer/useThreeStage.ts
@@ -200,6 +200,7 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
   const [selectedUuid, setSelectedUuid] = useState<string | null>(null);
   const [pickingEnabled, setPickingEnabled] = useState(true);
   const pickingEnabledRef = useRef(true);
+  const [hasSkin, setHasSkin] = useState(false);
 
   // Keep refs in sync so the render loop can gate the mixer without re-running.
   useEffect(() => {
@@ -372,7 +373,14 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
 
         // Index objects for tree ↔ viewer selection.
         stage.objectsByUuid = new Map();
-        model.traverse((object) => stage.objectsByUuid.set(object.uuid, object));
+        let skinned = false;
+        model.traverse((object) => {
+          stage.objectsByUuid.set(object.uuid, object);
+          if ((object as THREE.SkinnedMesh).isSkinnedMesh) {
+            skinned = true;
+          }
+        });
+        setHasSkin(skinned);
 
         // Extract serializable model data for the preview UI.
         stage.materials = new Map();
@@ -534,6 +542,23 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
     []
   );
 
+  const setWireframe = useCallback((enabled: boolean) => {
+    const stage = refs.current;
+    if (!stage?.model) {
+      return;
+    }
+    stage.model.traverse((object) => {
+      const mesh = object as THREE.Mesh;
+      if (!mesh.isMesh) {
+        return;
+      }
+      const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+      materials.forEach((material) => {
+        (material as THREE.MeshStandardMaterial).wireframe = enabled;
+      });
+    });
+  }, []);
+
   const resetView = useCallback(() => {
     const stage = refs.current;
     if (!stage || !stage.model) {
@@ -569,6 +594,8 @@ export function useThreeStage(bytes: ArrayBuffer | null) {
     selectMesh,
     pickingEnabled,
     setPickingEnabled,
+    hasSkin,
+    setWireframe,
     resetView,
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@gltf-transform/core": "^4.4.1",
         "@gltf-transform/functions": "^4.4.1",
         "@vercel/analytics": "^1.5.0",
+        "meshoptimizer": "^1.2.0",
         "next": "14.2.35",
         "react": "^18",
         "react-dom": "^18",
@@ -2412,6 +2413,13 @@
         "fflate": "~0.8.2",
         "meshoptimizer": "~0.18.1"
       }
+    },
+    "node_modules/@types/three/node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/webxr": {
       "version": "0.5.19",
@@ -5714,10 +5722,10 @@
       }
     },
     "node_modules/meshoptimizer": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
-      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.2.0.tgz",
+      "integrity": "sha512-davRZeIJbxJrE24cwQle7ZDsxjdk/OphNOV83oX+efQinyoHY9Jcyz3MHbaoG0qySZajldGztNZ1RN/T19PZsg==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@gltf-transform/core": "^4.4.1",
     "@gltf-transform/functions": "^4.4.1",
     "@vercel/analytics": "^1.5.0",
+    "meshoptimizer": "^1.2.0",
     "next": "14.2.35",
     "react": "^18",
     "react-dom": "^18",


### PR DESCRIPTION
## 概要

旧 SimplifyModifier を破棄し、**gltf-transform `simplify`(meshoptimizer)**へ載せ替え (PRD F-5/F-8, architecture §6 1-6)。**既定オフ**、明示操作時のみ適用。

## 変更内容

- **Worker(`optimize.worker.ts`)**: `settings.reduce.enabled` 時のみ `meshoptimizer` を動的 import し `simplify({ ratio, error })` を適用。error は緩め(0.05)にしてスライダーの削減率が実際に到達できるように。prune/dedup の後・テクスチャ縮小の前に実行。
- **`PolygonReduceCard`**: トグル(**既定OFF**)+ 削減率スライダー + **「ワイヤーフレームで確認」チェックボックス**(ビューアにワイヤーフレーム表示)+ 結果ポリゴン数 + 警告。**スキン/アニメ付きモデルでは警告を強化**(アラートアイコン+コーラル)。
- **`useThreeStage`**: `hasSkin`(SkinnedMesh 検出)+ `setWireframe` を公開。
- `PipelineSettings.reduce` 追加。設定変更で自動試算が再実行(非破壊)。meshoptimizer 依存追加。

## 動作確認 (QA / Playwright, test2.glb = スキン付きアバター)

- ✅ **既定OFF**。トグルONで初めてスライダー/ワイヤーフレーム/ポリゴン数が表示・適用。
- ✅ **削減率スライダーが動く**: 20% → ポリゴン 16,659→**13,321**、50% → **8,494**(実削減が指定にほぼ一致)。
- ✅ **ワイヤーフレーム表示が動く**(ビューアのモデルがワイヤーフレーム化)。
- ✅ **Before/Afterにポリゴン数の変化が反映**(カードのポリゴン数 + サマリのサイズが更新)。
- ✅ **スキン付きモデル検出で警告強化**(⚠ スキン/アニメーション付きは崩れやすい旨)。出力glbは有効(試算完了=writeBinary成功)。**3Dビューへの反映は #37**。
- ✅ lint緑・test 48緑・build 成功・コンソールエラー0。

Closes #36