### PR TITLE
fix: ポリゴン削減の警告文言・デザインを Figma に一致させる

### DIFF
--- a/app/(v2)/features/optimize/PolygonReduceCard.module.scss
+++ b/app/(v2)/features/optimize/PolygonReduceCard.module.scss
@@ -1,20 +1,9 @@
 .warning {
-  display: flex;
-  align-items: center;
-  gap: var(--space-4);
   margin: 0;
   font-weight: 600;
   font-size: var(--font-size-11);
   line-height: 14px;
   color: var(--color-highlight);
-}
-
-.warningStrong {
-  color: var(--color-accent);
-
-  svg {
-    flex-shrink: 0;
-  }
 }
 
 .slider {

--- a/app/(v2)/features/optimize/PolygonReduceCard.tsx
+++ b/app/(v2)/features/optimize/PolygonReduceCard.tsx
@@ -5,7 +5,7 @@ import type { StageController } from "../../viewer/useThreeStage";
 import { useModelStore } from "../../store/modelStore";
 import { useOptimizeStore } from "../../store/optimizeStore";
 import { Switch } from "../../components/ui/Switch";
-import { LayersIcon, CheckIcon, AlertIcon } from "../../icons";
+import { LayersIcon, CheckIcon } from "../../icons";
 import card from "./OptimizeCard.module.scss";
 import styles from "./PolygonReduceCard.module.scss";
 
@@ -51,12 +51,7 @@ export function PolygonReduceCard({ stage }: { stage: StageController }) {
         <Switch checked={enabled} onChange={toggleEnabled} label="ポリゴンの削減" />
       </div>
       <p className={card.text}>面の数を減らして軽くします（既定はオフ）。</p>
-      <p className={`${styles.warning} ${stage.hasSkin ? styles.warningStrong : ""}`}>
-        {stage.hasSkin && <AlertIcon size={12} />}
-        {stage.hasSkin
-          ? "スキン／アニメーション付きモデルは形が崩れやすいためご注意ください"
-          : "※形やアニメーションが崩れる場合があります"}
-      </p>
+      <p className={styles.warning}>※形やアニメーションが崩れる場合があります</p>
 
       {enabled && (
         <>


### PR DESCRIPTION
## 概要

#36 のポリゴン削減カードの警告が Figma と文言・デザインの両方で異なっていたため修正。

- **Before**: スキン/アニメ付きモデル検出時にコーラル文字 + アラートアイコン + 「スキン／アニメーション付きモデルは形が崩れやすいためご注意ください」(実装方針「警告を強化」を過剰解釈)
- **After**: 常に **青(#2f6bff)の「※形やアニメーションが崩れる場合があります」**(Figma 準拠)

## 変更内容

- `PolygonReduceCard`: `hasSkin` 分岐と `AlertIcon` を除去し、常に青の定型警告を表示。`.warningStrong` スタイルを削除。

## 動作確認 (QA / Playwright, test2.glb = スキン付き)

- ✅ 警告テキスト「※形やアニメーションが崩れる場合があります」、色 `rgb(47,107,255)`(=#2f6bff 青)を実測確認。
- ✅ lint緑・`/legacy` 200・test 48緑・コンソールエラー0。