### PR TITLE
Add non-destructive material / texture-slot deletion (1-8)

### DIFF
--- a/app/(v2)/features/optimize/useOptimizePipeline.ts
+++ b/app/(v2)/features/optimize/useOptimizePipeline.ts
@@ -29,6 +29,8 @@ export function useOptimizePipeline() {
   const textureMaxSize = useOptimizeStore((state) => state.settings.textureMaxSize);
   const reduceEnabled = useOptimizeStore((state) => state.settings.reduce.enabled);
   const reduceRatio = useOptimizeStore((state) => state.settings.reduce.ratio);
+  const deletedMaterials = useOptimizeStore((state) => state.settings.deletedMaterials);
+  const deletedTextureSlots = useOptimizeStore((state) => state.settings.deletedTextureSlots);
   const setStatus = useOptimizeStore((state) => state.setStatus);
   const setResult = useOptimizeStore((state) => state.setResult);
   const setEstimate = useOptimizeStore((state) => state.setEstimate);
@@ -46,6 +48,8 @@ export function useOptimizePipeline() {
         pruneDedup,
         textureMaxSize,
         reduce: { enabled: reduceEnabled, ratio: reduceRatio },
+        deletedMaterials,
+        deletedTextureSlots,
       })
         .then((result) => {
           if (cancelled) {
@@ -82,6 +86,8 @@ export function useOptimizePipeline() {
     textureMaxSize,
     reduceEnabled,
     reduceRatio,
+    deletedMaterials,
+    deletedTextureSlots,
     setStatus,
     setResult,
     setEstimate,

--- a/app/(v2)/features/preview/MaterialTab.module.scss
+++ b/app/(v2)/features/preview/MaterialTab.module.scss
@@ -11,15 +11,8 @@
 .row {
   display: flex;
   align-items: center;
-  gap: var(--space-4);
   width: 100%;
-  padding: var(--space-4) var(--space-8);
-  border: none;
   border-radius: var(--radius-sm);
-  background: transparent;
-  font-family: inherit;
-  text-align: left;
-  cursor: pointer;
 
   &:hover {
     background: var(--color-highlight-soft);
@@ -28,6 +21,60 @@
 
 .rowActive {
   background: var(--color-highlight-soft);
+}
+
+.expand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex: 1;
+  min-width: 0;
+  padding: var(--space-4) var(--space-8);
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  margin-right: var(--space-4);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--color-highlight-soft);
+  }
+}
+
+.danger {
+  color: var(--color-text-faint);
+
+  &:hover {
+    color: var(--color-danger);
+  }
+}
+
+.restore {
+  color: var(--color-highlight);
+}
+
+.deleted {
+  opacity: 0.4;
+
+  .name,
+  .textureType,
+  .textureName {
+    text-decoration: line-through;
+  }
 }
 
 .headIcon {

--- a/app/(v2)/features/preview/MaterialTab.tsx
+++ b/app/(v2)/features/preview/MaterialTab.tsx
@@ -3,8 +3,9 @@
 import { useState } from "react";
 import type { StageController } from "../../viewer/useThreeStage";
 import { useUiStore } from "../../store/uiStore";
+import { useOptimizeStore } from "../../store/optimizeStore";
 import { formatFileSize } from "../../lib/formatFileSize";
-import { SphereIcon, ZapIcon, ArrowRightIcon } from "../../icons";
+import { SphereIcon, ZapIcon, ArrowRightIcon, TrashIcon, RotateIcon } from "../../icons";
 import { TabCard } from "./TabCard";
 import styles from "./MaterialTab.module.scss";
 
@@ -25,11 +26,21 @@ function ValueBar({ label, value }: { label: string; value: number }) {
 
 /**
  * 見た目: material list. Selecting a material reveals its textures and read-only
- * roughness / metalness bars. Multiple materials can stay open at once.
+ * roughness / metalness bars. Materials and individual texture slots can be
+ * marked for deletion (F-10) — non-destructive: the mark drives the optimize
+ * pipeline and is fully undoable (toggle again, or リセット), so no confirm
+ * dialog is needed.
  */
 export function MaterialTab({ stage }: { stage: StageController }) {
   const [openIds, setOpenIds] = useState<Set<string>>(new Set());
   const setMode = useUiStore((state) => state.setMode);
+  const deletedMaterials = useOptimizeStore((state) => state.settings.deletedMaterials);
+  const deletedTextureSlots = useOptimizeStore((state) => state.settings.deletedTextureSlots);
+  const toggleMaterialDeleted = useOptimizeStore((state) => state.toggleMaterialDeleted);
+  const toggleTextureSlotDeleted = useOptimizeStore((state) => state.toggleTextureSlotDeleted);
+
+  const isSlotDeleted = (material: string, slot: string) =>
+    deletedTextureSlots.some((entry) => entry.material === material && entry.slot === slot);
 
   const toggle = (id: string) =>
     setOpenIds((prev) => {
@@ -47,42 +58,84 @@ export function MaterialTab({ stage }: { stage: StageController }) {
       <ul className={styles.list}>
         {stage.materials.map((material) => {
           const open = openIds.has(material.id);
+          const materialDeleted = deletedMaterials.includes(material.name);
           return (
             <li key={material.id}>
-              <button
-                type="button"
-                className={`${styles.row} ${open ? styles.rowActive : ""}`}
-                aria-expanded={open}
-                onClick={() => toggle(material.id)}
-              >
-                <span className={styles.headIcon}>
-                  <SphereIcon size={14} />
-                </span>
-                <span className={styles.name}>{material.name}</span>
-              </button>
+              <div className={`${styles.row} ${open ? styles.rowActive : ""}`}>
+                <button
+                  type="button"
+                  className={`${styles.expand} ${materialDeleted ? styles.deleted : ""}`}
+                  aria-expanded={open}
+                  onClick={() => toggle(material.id)}
+                >
+                  <span className={styles.headIcon}>
+                    <SphereIcon size={14} />
+                  </span>
+                  <span className={styles.name}>{material.name}</span>
+                </button>
+                <button
+                  type="button"
+                  className={`${styles.action} ${materialDeleted ? styles.restore : styles.danger}`}
+                  aria-label={materialDeleted ? `${material.name} を戻す` : `${material.name} を削除`}
+                  aria-pressed={materialDeleted}
+                  onClick={() => toggleMaterialDeleted(material.name)}
+                >
+                  {materialDeleted ? <RotateIcon size={14} /> : <TrashIcon size={14} />}
+                </button>
+              </div>
               {open && (
                 <div className={styles.details}>
                   {material.textures.length > 0 && (
                     <div className={styles.textureBlock}>
                       <span className={styles.textureHeading}>テクスチャ</span>
-                      {material.textures.map((texture, index) => (
-                        <div key={`${texture.type}-${index}`} className={styles.texture}>
-                          {/* eslint-disable-next-line @next/next/no-img-element */}
-                          <img className={styles.thumb} src={texture.url} alt={texture.type} />
-                          <div className={styles.textureMeta}>
-                            <span className={styles.textureType}>{texture.type}</span>
-                            {texture.name && <span className={styles.textureName}>{texture.name}</span>}
-                            {texture.width > 0 && (
-                              <span className={styles.textureDim}>
-                                {texture.width} × {texture.height} px
-                              </span>
-                            )}
-                            {texture.byteLength > 0 && (
-                              <span className={styles.textureSize}>{formatFileSize(texture.byteLength)}</span>
+                      {material.textures.map((texture, index) => {
+                        const slotDeleted =
+                          materialDeleted || isSlotDeleted(material.name, texture.type);
+                        return (
+                          <div
+                            key={`${texture.type}-${index}`}
+                            className={`${styles.texture} ${slotDeleted ? styles.deleted : ""}`}
+                          >
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img className={styles.thumb} src={texture.url} alt={texture.type} />
+                            <div className={styles.textureMeta}>
+                              <span className={styles.textureType}>{texture.type}</span>
+                              {texture.name && <span className={styles.textureName}>{texture.name}</span>}
+                              {texture.width > 0 && (
+                                <span className={styles.textureDim}>
+                                  {texture.width} × {texture.height} px
+                                </span>
+                              )}
+                              {texture.byteLength > 0 && (
+                                <span className={styles.textureSize}>{formatFileSize(texture.byteLength)}</span>
+                              )}
+                            </div>
+                            {!materialDeleted && (
+                              <button
+                                type="button"
+                                className={`${styles.action} ${
+                                  isSlotDeleted(material.name, texture.type) ? styles.restore : styles.danger
+                                }`}
+                                aria-label={
+                                  isSlotDeleted(material.name, texture.type)
+                                    ? `${texture.type} を戻す`
+                                    : `${texture.type} を削除`
+                                }
+                                aria-pressed={isSlotDeleted(material.name, texture.type)}
+                                onClick={() =>
+                                  toggleTextureSlotDeleted({ material: material.name, slot: texture.type })
+                                }
+                              >
+                                {isSlotDeleted(material.name, texture.type) ? (
+                                  <RotateIcon size={14} />
+                                ) : (
+                                  <TrashIcon size={14} />
+                                )}
+                              </button>
                             )}
                           </div>
-                        </div>
-                      ))}
+                        );
+                      })}
                     </div>
                   )}
                   <ValueBar label="粗さ (Roughness)" value={material.roughness} />

--- a/app/(v2)/pipeline/optimize.worker.ts
+++ b/app/(v2)/pipeline/optimize.worker.ts
@@ -1,8 +1,8 @@
 // Optimization Worker: runs the non-destructive @gltf-transform pipeline off the
 // main thread. gltf-transform is dynamically imported (kept out of the main
 // bundle). Input is a copy of the original bytes; output is fresh bytes.
-import type { Document } from "@gltf-transform/core";
-import type { PipelineRequest, PipelineResponse } from "./types";
+import type { Document, Material } from "@gltf-transform/core";
+import type { PipelineRequest, PipelineResponse, PipelineSettings } from "./types";
 
 const worker = self as unknown as Worker;
 const post = (message: PipelineResponse, transfer?: Transferable[]) =>
@@ -56,6 +56,55 @@ async function downscaleTextures(document: Document, maxSize: number): Promise<v
   }
 }
 
+/** Drop a single texture-map slot from a material. Labels match the preview UI
+ *  (`MAP_KEYS` in useThreeStage); Roughness/Metalness share the glTF
+ *  metallicRoughness texture, so either removes it. */
+function clearTextureSlot(material: Material, slot: string): void {
+  switch (slot) {
+    case "BaseColor":
+      material.setBaseColorTexture(null);
+      break;
+    case "Normal":
+      material.setNormalTexture(null);
+      break;
+    case "Roughness":
+    case "Metalness":
+      material.setMetallicRoughnessTexture(null);
+      break;
+    case "Emissive":
+      material.setEmissiveTexture(null);
+      break;
+    case "AO":
+      material.setOcclusionTexture(null);
+      break;
+  }
+}
+
+/**
+ * Apply the non-destructive slot/material deletions (F-10). Deleting a material
+ * detaches it from every primitive (meshes render blank, as in legacy); prune
+ * afterwards drops the now-orphaned materials/textures so the size shrinks.
+ * Returns true when anything was deleted (so the caller can prune even with the
+ * prune/dedup toggle off).
+ */
+function applyDeletions(document: Document, settings: PipelineSettings): boolean {
+  const { deletedMaterials, deletedTextureSlots } = settings;
+  if (deletedMaterials.length === 0 && deletedTextureSlots.length === 0) {
+    return false;
+  }
+  for (const material of document.getRoot().listMaterials()) {
+    const name = material.getName();
+    if (deletedMaterials.includes(name)) {
+      material.dispose();
+      continue;
+    }
+    for (const { slot } of deletedTextureSlots.filter((entry) => entry.material === name)) {
+      clearTextureSlot(material, slot);
+    }
+  }
+  return true;
+}
+
 /** Sum of triangles across all mesh primitives. */
 function countPolygons(document: Document): number {
   let triangles = 0;
@@ -86,8 +135,14 @@ worker.onmessage = async (event: MessageEvent<PipelineRequest>) => {
     const copyright = document.getRoot().getAsset().copyright;
 
     const before = propertyCount(document);
+    // Non-destructive material/texture-slot deletion (F-10). Prune afterwards to
+    // drop orphaned data — done even if prune/dedup is off, otherwise deletions
+    // would not shrink the file.
+    const hasDeletions = applyDeletions(document, settings);
     if (settings.pruneDedup) {
       await document.transform(functions.prune(), functions.dedup());
+    } else if (hasDeletions) {
+      await document.transform(functions.prune());
     }
     const after = propertyCount(document);
 

--- a/app/(v2)/pipeline/types.ts
+++ b/app/(v2)/pipeline/types.ts
@@ -4,6 +4,14 @@
 /** Max texture edge length; `"off"` disables texture downscaling. */
 export type TextureMaxSize = 2048 | 1024 | 512 | "off";
 
+/** A single texture map slot on a material, keyed by material name + map label. */
+export interface TextureSlotRef {
+  /** Material name (the deletion key — matches @gltf-transform material names). */
+  material: string;
+  /** Map label (BaseColor / Normal / Roughness / Metalness / Emissive / AO). */
+  slot: string;
+}
+
 export interface PipelineSettings {
   /** prune unused data + dedup duplicates. */
   pruneDedup: boolean;
@@ -15,6 +23,10 @@ export interface PipelineSettings {
     /** Target ratio of triangles to keep (0–1). */
     ratio: number;
   };
+  /** Materials (by name) to drop — non-destructive; reset restores them (F-10). */
+  deletedMaterials: string[];
+  /** Individual texture-map slots to drop from a material (F-10). */
+  deletedTextureSlots: TextureSlotRef[];
 }
 
 export interface PipelineStats {

--- a/app/(v2)/store/optimizeStore.ts
+++ b/app/(v2)/store/optimizeStore.ts
@@ -7,6 +7,12 @@ export type TextureMaxSize = 2048 | 1024 | 512 | "off";
 /** Pipeline status. Worker execution is wired up in Phase 1. */
 export type OptimizeStatus = "idle" | "estimating" | "transforming" | "ready" | "error";
 
+/** A texture map slot on a material, keyed by material name + map label. */
+export interface TextureSlotRef {
+  material: string;
+  slot: string;
+}
+
 export interface OptimizeSettings {
   /** prune unused data + dedup (safe, applied by default). */
   pruneDedup: boolean;
@@ -16,6 +22,10 @@ export interface OptimizeSettings {
     enabled: boolean;
     ratio: number; // kept ratio, 0..1
   };
+  /** Materials (by name) marked for deletion — non-destructive (F-10). */
+  deletedMaterials: string[];
+  /** Texture-map slots marked for deletion (F-10). */
+  deletedTextureSlots: TextureSlotRef[];
 }
 
 /** F-17 auto-estimation result. `null` in the store means "not estimated yet". */
@@ -39,6 +49,8 @@ const DEFAULT_SETTINGS: OptimizeSettings = {
   pruneDedup: true,
   textureMaxSize: 1024, // recommended default
   reduce: { enabled: false, ratio: 0.5 },
+  deletedMaterials: [],
+  deletedTextureSlots: [],
 };
 
 interface OptimizeState {
@@ -47,6 +59,10 @@ interface OptimizeState {
   estimate: OptimizeEstimate | null;
   result: OptimizeResult | null;
   setSettings: (patch: Partial<OptimizeSettings>) => void;
+  /** Toggle a material's deletion (non-destructive, undoable). */
+  toggleMaterialDeleted: (name: string) => void;
+  /** Toggle a texture slot's deletion (non-destructive, undoable). */
+  toggleTextureSlotDeleted: (slot: TextureSlotRef) => void;
   setStatus: (status: OptimizeStatus) => void;
   setEstimate: (estimate: OptimizeEstimate | null) => void;
   setResult: (result: OptimizeResult | null) => void;
@@ -63,6 +79,35 @@ export const useOptimizeStore = create<OptimizeState>()(
       result: null,
       setSettings: (patch) =>
         set((state) => ({ settings: { ...state.settings, ...patch } }), false, "setSettings"),
+      toggleMaterialDeleted: (name) =>
+        set(
+          (state) => {
+            const list = state.settings.deletedMaterials;
+            const deletedMaterials = list.includes(name)
+              ? list.filter((entry) => entry !== name)
+              : [...list, name];
+            return { settings: { ...state.settings, deletedMaterials } };
+          },
+          false,
+          "toggleMaterialDeleted"
+        ),
+      toggleTextureSlotDeleted: (slot) =>
+        set(
+          (state) => {
+            const list = state.settings.deletedTextureSlots;
+            const exists = list.some(
+              (entry) => entry.material === slot.material && entry.slot === slot.slot
+            );
+            const deletedTextureSlots = exists
+              ? list.filter(
+                  (entry) => !(entry.material === slot.material && entry.slot === slot.slot)
+                )
+              : [...list, slot];
+            return { settings: { ...state.settings, deletedTextureSlots } };
+          },
+          false,
+          "toggleTextureSlotDeleted"
+        ),
       setStatus: (status) => set({ status }, false, "setStatus"),
       setEstimate: (estimate) => set({ estimate }, false, "setEstimate"),
       setResult: (result) => set({ result }, false, "setResult"),

--- a/app/(v2)/styles/tokens.scss
+++ b/app/(v2)/styles/tokens.scss
@@ -10,6 +10,7 @@
   --color-on-accent: #ffffff; // text/icon on an accent fill
   --color-highlight: #2f6bff; // Figma color/blue-8 — upload icon, notes, focus
   --color-highlight-soft: #eaf0ff; // Figma color/blue-2 — selected row background
+  --color-danger: #e5484d; // destructive action (material / texture-slot delete)
 
   // Surface & text ramp (light)
   --color-bg: #f7f5f2; // Figma color/biege-3
@@ -60,6 +61,7 @@
   --color-accent-strong: #ff6a3d;
   --color-accent-soft: #3a2a22;
   --color-highlight: #6f9bff;
+  --color-danger: #f2555a;
 
   --color-bg: #1b1a18;
   --color-viewer-bg: #1b1a18; // dark: unchanged (matches the app background)


### PR DESCRIPTION
## 概要

旧版の破壊的なマテリアル/テクスチャスロット削除を、非破壊パイプラインの「設定」として載せ替える（issue 1-8 / F-10）。削除は optimizeStore の設定（`deletedMaterials` / `deletedTextureSlots`）として保持し、元 bytes からの再生成で表現するため、完全に取り消し可能で確認ダイアログを不要にした。

## 変更点

- **optimizeStore**: `deletedMaterials` / `deletedTextureSlots` 設定 + トグルアクションを追加。既定は空で、リセットで復活。
- **Worker**: `applyDeletions()` が対象マテリアルを `dispose()`（メッシュは旧版同様デフォルトマテリアルにフォールバック）、対象マップスロットを解除。孤立データを実際に削減するため、prune/dedup トグルがオフでも削除がある時は prune を実行。Roughness/Metalness は glTF の metallicRoughness テクスチャを共有するため、どちらの削除でも解除。
- **MaterialTab**: マテリアル行とテクスチャサムネイルにゴミ箱トグル。マーク時は淡色+取り消し線、ゴミ箱→戻すアイコンに変化。マテリアルごと削除時はスロット操作を隠す。
- **tokens**: 破壊的操作用に `--color-danger` を追加。

## QA (Playwright MCP, port 3100, test2.glb)

- ✅ スロット/マテリアルのマークがトグルし、モード切替をまたいで保持。
- ✅ **サマリ反映**: prune/texture をオフにして Body マテリアル + その Normal マップを削除 → `-9% (12.0MB→10.9MB)`。両方戻すと `0% (12.0MB→12.0MB)` に復帰（非破壊を実証）。
- ✅ **保存内容確認**: Glasses を削除して保存した glb はマテリアル 9→8、孤立テクスチャが prune され 18→16。
- ✅ 確認ダイアログなし。console エラー 0 件。`/legacy` 200。lint / test(48 passed) / build 全パス。

Closes #38