### PR TITLE
Land freshly uploaded models in preview mode

### DIFF
--- a/app/(v2)/hooks/useModelUpload.ts
+++ b/app/(v2)/hooks/useModelUpload.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { useModelStore } from "../store/modelStore";
+import { useUiStore } from "../store/uiStore";
 
 const GLB_EXTENSION = ".glb";
 
@@ -10,6 +11,7 @@ const GLB_EXTENSION = ".glb";
  */
 export function useModelUpload() {
   const loadModel = useModelStore((state) => state.loadModel);
+  const setMode = useUiStore((state) => state.setMode);
   const [error, setError] = useState<string | null>(null);
 
   const acceptFiles = useCallback(
@@ -25,8 +27,11 @@ export function useModelUpload() {
       setError(null);
       const originalBytes = await file.arrayBuffer();
       loadModel(originalBytes, { name: file.name, size: file.size });
+      // Always land a freshly uploaded model in preview, even if the persisted
+      // mode was "optimize" from a previous session.
+      setMode("preview");
     },
-    [loadModel]
+    [loadModel, setMode]
   );
 
   return { acceptFiles, error };


### PR DESCRIPTION
## 概要

UI モード（プレビュー/軽量化）は localStorage に永続化されているため、前回セッションで軽量化タブを使っていると、新しくモデルをアップロードしても軽量化タブで開いてしまっていた。アップロード時に mode を `preview` にリセットし、デフォルトの着地点を常にプレビューにする。

## 変更点

- `useModelUpload`: `loadModel` 後に `setMode("preview")` を呼ぶ。

## QA (Playwright MCP, port 3100)

- ✅ localStorage の mode を `optimize` にして再読込 → 軽量化タブ選択状態を確認。
- ✅ その状態で test2.glb をアップロード → **プレビュータブが選択**（軽量化は非選択）に切り替わることを確認。
- ✅ console エラー 0 件 / lint / build パス。