### PR TITLE
Add per-texture resolution control (テクスチャ個別設定 / Figma 78-362)

### DIFF
--- a/app/(v2)/features/optimize/OptimizeSidebar.tsx
+++ b/app/(v2)/features/optimize/OptimizeSidebar.tsx
@@ -20,7 +20,7 @@ export function OptimizeSidebar({ stage }: { stage: StageController }) {
     <div className={styles.sidebar}>
       <h2 className={styles.heading}>軽量化の設定はカスタマイズが可能です</h2>
       <PruneDedupCard />
-      <TextureOptimizeCard />
+      <TextureOptimizeCard stage={stage} />
       <PolygonReduceCard stage={stage} />
       <BeforeAfterSummary />
     </div>

--- a/app/(v2)/features/optimize/TextureOptimizeCard.module.scss
+++ b/app/(v2)/features/optimize/TextureOptimizeCard.module.scss
@@ -6,6 +6,153 @@
   color: var(--color-highlight);
 }
 
+.individualToggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border: 1.5px solid var(--color-text-faint);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: transparent;
+}
+
+.checkOn {
+  border-color: var(--color-highlight);
+  background: var(--color-highlight);
+  color: var(--color-on-accent);
+}
+
+.individualLabel {
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  color: var(--color-text);
+}
+
+.textureList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+  width: 100%;
+}
+
+.textureRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  width: 100%;
+}
+
+.thumb {
+  flex-shrink: 0;
+  width: 72px;
+  height: 72px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  object-fit: cover;
+}
+
+.textureMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.textureType {
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-text-faint);
+}
+
+.textureName {
+  overflow: hidden;
+  font-weight: 600;
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  color: var(--color-text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.textureDim {
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-text-muted);
+}
+
+.textureSize {
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-text-muted);
+}
+
+.selectWrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
+// Orange caret box on the right edge of the select (Figma).
+.selectWrap::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 26px;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  background: var(--color-accent);
+  pointer-events: none;
+}
+
+.selectWrap::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 9px;
+  width: 0;
+  height: 0;
+  transform: translateY(-50%);
+  border-top: 5px solid var(--color-on-accent);
+  border-right: 4px solid transparent;
+  border-left: 4px solid transparent;
+  pointer-events: none;
+}
+
+.select {
+  width: 128px;
+  padding: var(--space-8) var(--space-30) var(--space-8) var(--space-8);
+  border: 1px solid var(--color-border-2);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  appearance: none;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+
 .chips {
   display: flex;
   gap: var(--space-8);

--- a/app/(v2)/features/optimize/TextureOptimizeCard.module.scss
+++ b/app/(v2)/features/optimize/TextureOptimizeCard.module.scss
@@ -56,6 +56,58 @@
   width: 100%;
 }
 
+// Right column: delete/restore at the top, resolution select at the bottom.
+.rowControls {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: space-between;
+  align-self: stretch;
+  flex-shrink: 0;
+  gap: var(--space-4);
+}
+
+.action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--color-highlight-soft);
+  }
+}
+
+.danger {
+  color: var(--color-text-faint);
+
+  &:hover {
+    color: var(--color-danger);
+  }
+}
+
+.restore {
+  color: var(--color-highlight);
+}
+
+.deleted {
+  .thumb,
+  .textureMeta {
+    opacity: 0.4;
+  }
+
+  .textureType,
+  .textureName {
+    text-decoration: line-through;
+  }
+}
+
 .thumb {
   flex-shrink: 0;
   width: 72px;
@@ -136,7 +188,7 @@
 
 .select {
   width: 128px;
-  padding: var(--space-8) var(--space-30) var(--space-8) var(--space-8);
+  padding: var(--space-4) var(--space-30) var(--space-4) var(--space-8);
   border: 1px solid var(--color-border-2);
   border-radius: var(--radius-sm);
   background: var(--color-surface);

--- a/app/(v2)/features/optimize/TextureOptimizeCard.tsx
+++ b/app/(v2)/features/optimize/TextureOptimizeCard.tsx
@@ -6,7 +6,7 @@ import { useOptimizeStore } from "../../store/optimizeStore";
 import { useThreeStage } from "../../viewer/useThreeStage";
 import { Switch } from "../../components/ui/Switch";
 import { formatFileSize } from "../../lib/formatFileSize";
-import { ImageIcon, CheckIcon } from "../../icons";
+import { ImageIcon, CheckIcon, TrashIcon, RotateIcon } from "../../icons";
 import card from "./OptimizeCard.module.scss";
 import styles from "./TextureOptimizeCard.module.scss";
 
@@ -55,16 +55,18 @@ function collectTextures(stage: StageController): TextureRow[] {
   return Array.from(seen.values());
 }
 
-/** Per-texture resolution dropdown (変更なし + valid downscales). */
+/** Per-texture row: resolution dropdown + a non-destructive delete toggle. */
 function TextureRowItem({ texture }: { texture: TextureRow }) {
   const override = useOptimizeStore((state) => state.settings.textureOverrides[texture.name]);
   const setTextureOverride = useOptimizeStore((state) => state.setTextureOverride);
+  const deleted = useOptimizeStore((state) => state.settings.deletedTextures.includes(texture.name));
+  const toggleTextureDeleted = useOptimizeStore((state) => state.toggleTextureDeleted);
 
   const longest = Math.max(texture.width, texture.height);
   const choices = RESOLUTIONS.filter((resolution) => resolution < longest);
 
   return (
-    <div className={styles.textureRow}>
+    <div className={`${styles.textureRow} ${deleted ? styles.deleted : ""}`}>
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img className={styles.thumb} src={texture.url} alt={texture.type} />
       <div className={styles.textureMeta}>
@@ -77,26 +79,37 @@ function TextureRowItem({ texture }: { texture: TextureRow }) {
           <span className={styles.textureSize}>{formatFileSize(texture.byteLength)}</span>
         )}
       </div>
-      <div className={styles.selectWrap}>
-        <select
-          className={styles.select}
-          aria-label={`${texture.name} の解像度`}
-          value={override ?? "keep"}
-          onChange={(event) =>
-            setTextureOverride(
-              texture.name,
-              event.target.value === "keep" ? null : Number(event.target.value)
-            )
-          }
-          disabled={choices.length === 0}
+      <div className={styles.rowControls}>
+        <button
+          type="button"
+          className={`${styles.action} ${deleted ? styles.restore : styles.danger}`}
+          aria-label={deleted ? `${texture.name} を戻す` : `${texture.name} を削除`}
+          aria-pressed={deleted}
+          onClick={() => toggleTextureDeleted(texture.name)}
         >
-          <option value="keep">変更なし</option>
-          {choices.map((resolution) => (
-            <option key={resolution} value={resolution}>
-              {resolution === RECOMMENDED ? `${resolution}（おすすめ）` : resolution}
-            </option>
-          ))}
-        </select>
+          {deleted ? <RotateIcon size={14} /> : <TrashIcon size={14} />}
+        </button>
+        <div className={styles.selectWrap}>
+          <select
+            className={styles.select}
+            aria-label={`${texture.name} の解像度`}
+            value={override ?? "keep"}
+            onChange={(event) =>
+              setTextureOverride(
+                texture.name,
+                event.target.value === "keep" ? null : Number(event.target.value)
+              )
+            }
+            disabled={deleted || choices.length === 0}
+          >
+            <option value="keep">変更なし</option>
+            {choices.map((resolution) => (
+              <option key={resolution} value={resolution}>
+                {resolution === RECOMMENDED ? `${resolution}（おすすめ）` : resolution}
+              </option>
+            ))}
+          </select>
+        </div>
       </div>
     </div>
   );

--- a/app/(v2)/features/optimize/TextureOptimizeCard.tsx
+++ b/app/(v2)/features/optimize/TextureOptimizeCard.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useModelStore } from "../../store/modelStore";
 import { useOptimizeStore } from "../../store/optimizeStore";
+import { useThreeStage } from "../../viewer/useThreeStage";
 import { Switch } from "../../components/ui/Switch";
-import { ImageIcon } from "../../icons";
+import { formatFileSize } from "../../lib/formatFileSize";
+import { ImageIcon, CheckIcon } from "../../icons";
 import card from "./OptimizeCard.module.scss";
 import styles from "./TextureOptimizeCard.module.scss";
+
+type StageController = ReturnType<typeof useThreeStage>;
 
 type Resolution = 512 | 1024 | 2048;
 
@@ -16,11 +20,96 @@ const OPTIONS: { value: Resolution; sub: string }[] = [
   { value: 2048, sub: "高品質" },
 ];
 
-/** テクスチャの最適化: bulk downscale of every texture map to a chosen max edge. */
-export function TextureOptimizeCard() {
+/** Resolution offered per-texture (only downscales below the current edge). */
+const RESOLUTIONS: Resolution[] = [2048, 1024, 512];
+/** Recommended per-texture target (matches the global "おすすめ" chip). */
+const RECOMMENDED: Resolution = 1024;
+
+interface TextureRow {
+  name: string;
+  type: string;
+  url: string;
+  width: number;
+  height: number;
+  byteLength: number;
+}
+
+/** Unique textures across all materials, keyed by name (the pipeline's key). */
+function collectTextures(stage: StageController): TextureRow[] {
+  const seen = new Map<string, TextureRow>();
+  for (const material of stage.materials) {
+    for (const texture of material.textures) {
+      if (!texture.name || seen.has(texture.name)) {
+        continue;
+      }
+      seen.set(texture.name, {
+        name: texture.name,
+        type: texture.type,
+        url: texture.url,
+        width: texture.width,
+        height: texture.height,
+        byteLength: texture.byteLength,
+      });
+    }
+  }
+  return Array.from(seen.values());
+}
+
+/** Per-texture resolution dropdown (変更なし + valid downscales). */
+function TextureRowItem({ texture }: { texture: TextureRow }) {
+  const override = useOptimizeStore((state) => state.settings.textureOverrides[texture.name]);
+  const setTextureOverride = useOptimizeStore((state) => state.setTextureOverride);
+
+  const longest = Math.max(texture.width, texture.height);
+  const choices = RESOLUTIONS.filter((resolution) => resolution < longest);
+
+  return (
+    <div className={styles.textureRow}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img className={styles.thumb} src={texture.url} alt={texture.type} />
+      <div className={styles.textureMeta}>
+        <span className={styles.textureType}>{texture.type}</span>
+        <span className={styles.textureName}>{texture.name}</span>
+        <span className={styles.textureDim}>
+          {texture.width} × {texture.height} px
+        </span>
+        {texture.byteLength > 0 && (
+          <span className={styles.textureSize}>{formatFileSize(texture.byteLength)}</span>
+        )}
+      </div>
+      <div className={styles.selectWrap}>
+        <select
+          className={styles.select}
+          aria-label={`${texture.name} の解像度`}
+          value={override ?? "keep"}
+          onChange={(event) =>
+            setTextureOverride(
+              texture.name,
+              event.target.value === "keep" ? null : Number(event.target.value)
+            )
+          }
+          disabled={choices.length === 0}
+        >
+          <option value="keep">変更なし</option>
+          {choices.map((resolution) => (
+            <option key={resolution} value={resolution}>
+              {resolution === RECOMMENDED ? `${resolution}（おすすめ）` : resolution}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}
+
+/** テクスチャの最適化: bulk downscale, with an optional per-texture ("個別で設定する") mode. */
+export function TextureOptimizeCard({ stage }: { stage: StageController }) {
   const maxTextureSize = useModelStore((state) => state.meta?.maxTextureSize);
   const textureMaxSize = useOptimizeStore((state) => state.settings.textureMaxSize);
+  const perTexture = useOptimizeStore((state) => state.settings.perTexture);
   const setSettings = useOptimizeStore((state) => state.setSettings);
+
+  const textures = useMemo(() => collectTextures(stage), [stage.materials]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const enabled = textureMaxSize !== "off";
   const [lastResolution, setLastResolution] = useState<Resolution>(
@@ -32,6 +121,22 @@ export function TextureOptimizeCard() {
   const selectResolution = (value: Resolution) => {
     setLastResolution(value);
     setSettings({ textureMaxSize: value });
+  };
+
+  const togglePerTexture = (on: boolean) => {
+    if (!on) {
+      setSettings({ perTexture: false });
+      return;
+    }
+    // Seed each texture with a sensible default: downscale the ones larger than
+    // the recommended edge, keep the rest ("変更なし").
+    const textureOverrides: Record<string, number> = {};
+    for (const texture of textures) {
+      if (Math.max(texture.width, texture.height) > RECOMMENDED) {
+        textureOverrides[texture.name] = RECOMMENDED;
+      }
+    }
+    setSettings({ perTexture: true, textureOverrides });
   };
 
   return (
@@ -56,20 +161,44 @@ export function TextureOptimizeCard() {
               </div>
             </div>
           )}
-          <div className={styles.chips} role="group" aria-label="最大解像度">
-            {OPTIONS.map(({ value, sub }) => (
-              <button
-                key={value}
-                type="button"
-                className={`${styles.chip} ${selected === value ? styles.chipActive : ""}`}
-                aria-pressed={selected === value}
-                onClick={() => selectResolution(value)}
-              >
-                <span className={styles.chipValue}>{value}</span>
-                <span className={styles.chipSub}>{sub}</span>
-              </button>
-            ))}
-          </div>
+
+          {textures.length > 0 && (
+            <button
+              type="button"
+              className={styles.individualToggle}
+              role="checkbox"
+              aria-checked={perTexture}
+              onClick={() => togglePerTexture(!perTexture)}
+            >
+              <span className={`${styles.check} ${perTexture ? styles.checkOn : ""}`}>
+                {perTexture && <CheckIcon size={10} />}
+              </span>
+              <span className={styles.individualLabel}>個別で設定する</span>
+            </button>
+          )}
+
+          {perTexture && textures.length > 0 ? (
+            <div className={styles.textureList}>
+              {textures.map((texture) => (
+                <TextureRowItem key={texture.name} texture={texture} />
+              ))}
+            </div>
+          ) : (
+            <div className={styles.chips} role="group" aria-label="最大解像度">
+              {OPTIONS.map(({ value, sub }) => (
+                <button
+                  key={value}
+                  type="button"
+                  className={`${styles.chip} ${selected === value ? styles.chipActive : ""}`}
+                  aria-pressed={selected === value}
+                  onClick={() => selectResolution(value)}
+                >
+                  <span className={styles.chipValue}>{value}</span>
+                  <span className={styles.chipSub}>{sub}</span>
+                </button>
+              ))}
+            </div>
+          )}
         </>
       )}
     </div>

--- a/app/(v2)/features/optimize/useOptimizePipeline.ts
+++ b/app/(v2)/features/optimize/useOptimizePipeline.ts
@@ -27,6 +27,8 @@ export function useOptimizePipeline() {
   const originalSize = useModelStore((state) => state.meta?.size ?? 0);
   const pruneDedup = useOptimizeStore((state) => state.settings.pruneDedup);
   const textureMaxSize = useOptimizeStore((state) => state.settings.textureMaxSize);
+  const perTexture = useOptimizeStore((state) => state.settings.perTexture);
+  const textureOverrides = useOptimizeStore((state) => state.settings.textureOverrides);
   const reduceEnabled = useOptimizeStore((state) => state.settings.reduce.enabled);
   const reduceRatio = useOptimizeStore((state) => state.settings.reduce.ratio);
   const setStatus = useOptimizeStore((state) => state.setStatus);
@@ -45,6 +47,8 @@ export function useOptimizePipeline() {
       runPipeline(bytes, {
         pruneDedup,
         textureMaxSize,
+        perTexture,
+        textureOverrides,
         reduce: { enabled: reduceEnabled, ratio: reduceRatio },
       })
         .then((result) => {
@@ -80,6 +84,8 @@ export function useOptimizePipeline() {
     originalSize,
     pruneDedup,
     textureMaxSize,
+    perTexture,
+    textureOverrides,
     reduceEnabled,
     reduceRatio,
     setStatus,

--- a/app/(v2)/features/optimize/useOptimizePipeline.ts
+++ b/app/(v2)/features/optimize/useOptimizePipeline.ts
@@ -29,6 +29,7 @@ export function useOptimizePipeline() {
   const textureMaxSize = useOptimizeStore((state) => state.settings.textureMaxSize);
   const perTexture = useOptimizeStore((state) => state.settings.perTexture);
   const textureOverrides = useOptimizeStore((state) => state.settings.textureOverrides);
+  const deletedTextures = useOptimizeStore((state) => state.settings.deletedTextures);
   const reduceEnabled = useOptimizeStore((state) => state.settings.reduce.enabled);
   const reduceRatio = useOptimizeStore((state) => state.settings.reduce.ratio);
   const setStatus = useOptimizeStore((state) => state.setStatus);
@@ -49,6 +50,7 @@ export function useOptimizePipeline() {
         textureMaxSize,
         perTexture,
         textureOverrides,
+        deletedTextures,
         reduce: { enabled: reduceEnabled, ratio: reduceRatio },
       })
         .then((result) => {
@@ -86,6 +88,7 @@ export function useOptimizePipeline() {
     textureMaxSize,
     perTexture,
     textureOverrides,
+    deletedTextures,
     reduceEnabled,
     reduceRatio,
     setStatus,

--- a/app/(v2)/pipeline/optimize.worker.ts
+++ b/app/(v2)/pipeline/optimize.worker.ts
@@ -71,6 +71,26 @@ async function downscaleTextures(
   }
 }
 
+/**
+ * Drop textures marked for deletion (F-10, by name). Disposing a texture
+ * detaches it from every material slot that referenced it; prune afterwards
+ * removes the now-orphaned image so the file actually shrinks. Returns true when
+ * anything was deleted.
+ */
+function deleteTextures(document: Document, names: string[]): boolean {
+  if (names.length === 0) {
+    return false;
+  }
+  let deleted = false;
+  for (const texture of document.getRoot().listTextures()) {
+    if (names.includes(texture.getName())) {
+      texture.dispose();
+      deleted = true;
+    }
+  }
+  return deleted;
+}
+
 /** Sum of triangles across all mesh primitives. */
 function countPolygons(document: Document): number {
   let triangles = 0;
@@ -101,8 +121,14 @@ worker.onmessage = async (event: MessageEvent<PipelineRequest>) => {
     const copyright = document.getRoot().getAsset().copyright;
 
     const before = propertyCount(document);
+    // Non-destructive texture deletion. Prune afterwards to drop the orphaned
+    // images — done even if prune/dedup is off, otherwise deletions would not
+    // shrink the file.
+    const hasDeletions = deleteTextures(document, settings.deletedTextures);
     if (settings.pruneDedup) {
       await document.transform(functions.prune(), functions.dedup());
+    } else if (hasDeletions) {
+      await document.transform(functions.prune());
     }
     const after = propertyCount(document);
 

--- a/app/(v2)/pipeline/optimize.worker.ts
+++ b/app/(v2)/pipeline/optimize.worker.ts
@@ -2,7 +2,7 @@
 // main thread. gltf-transform is dynamically imported (kept out of the main
 // bundle). Input is a copy of the original bytes; output is fresh bytes.
 import type { Document } from "@gltf-transform/core";
-import type { PipelineRequest, PipelineResponse } from "./types";
+import type { PipelineRequest, PipelineResponse, PipelineSettings } from "./types";
 
 const worker = self as unknown as Worker;
 const post = (message: PipelineResponse, transfer?: Transferable[]) =>
@@ -21,9 +21,24 @@ function propertyCount(document: Document): number {
   );
 }
 
-/** Downscale every texture whose longest edge exceeds `maxSize`, in place. */
-async function downscaleTextures(document: Document, maxSize: number): Promise<void> {
+/**
+ * Downscale textures whose longest edge exceeds a max, in place. In per-texture
+ * mode (`overrides` set) each texture uses its own target (keyed by name; absent
+ * = keep); otherwise every texture uses the global `maxSize`.
+ */
+async function downscaleTextures(
+  document: Document,
+  settings: Pick<PipelineSettings, "textureMaxSize" | "perTexture" | "textureOverrides">
+): Promise<void> {
   for (const texture of document.getRoot().listTextures()) {
+    const maxSize = settings.perTexture
+      ? settings.textureOverrides[texture.getName()]
+      : typeof settings.textureMaxSize === "number"
+        ? settings.textureMaxSize
+        : undefined;
+    if (typeof maxSize !== "number") {
+      continue; // 変更なし / texture optimization off
+    }
     const image = texture.getImage();
     const size = texture.getSize();
     const mimeType = texture.getMimeType() || "image/png";
@@ -106,12 +121,12 @@ worker.onmessage = async (event: MessageEvent<PipelineRequest>) => {
       );
     }
 
-    // Downscale all texture maps to the chosen max edge via OffscreenCanvas
-    // (the #30 fallback — reliable in-browser, keeps the original encoding so a
-    // JPEG stays a JPEG with no PNG bloat). Only textures larger than the box
-    // are touched.
-    if (typeof settings.textureMaxSize === "number") {
-      await downscaleTextures(document, settings.textureMaxSize);
+    // Downscale texture maps via OffscreenCanvas (the #30 fallback — reliable
+    // in-browser, keeps the original encoding so a JPEG stays a JPEG with no PNG
+    // bloat). Only textures larger than their target are touched. Runs for both
+    // the global max and per-texture ("個別で設定する") modes.
+    if (settings.perTexture || typeof settings.textureMaxSize === "number") {
+      await downscaleTextures(document, settings);
     }
 
     if (copyright) {

--- a/app/(v2)/pipeline/types.ts
+++ b/app/(v2)/pipeline/types.ts
@@ -15,6 +15,8 @@ export interface PipelineSettings {
   perTexture: boolean;
   /** texture name → target max edge (px). Absence/keep means "変更なし". */
   textureOverrides: Record<string, number>;
+  /** Textures (by name) to drop — non-destructive; reset/undo restores them. */
+  deletedTextures: string[];
   /** Polygon reduction (meshoptimizer simplify) — OFF by default. */
   reduce: {
     enabled: boolean;

--- a/app/(v2)/pipeline/types.ts
+++ b/app/(v2)/pipeline/types.ts
@@ -9,6 +9,12 @@ export interface PipelineSettings {
   pruneDedup: boolean;
   /** Downscale every texture map to this max edge; `"off"` keeps them. */
   textureMaxSize: TextureMaxSize;
+  /** Per-texture overrides ("個別で設定する"). When on, `textureOverrides`
+   *  drives downscaling per texture (keyed by texture name) instead of the
+   *  global `textureMaxSize`. */
+  perTexture: boolean;
+  /** texture name → target max edge (px). Absence/keep means "変更なし". */
+  textureOverrides: Record<string, number>;
   /** Polygon reduction (meshoptimizer simplify) — OFF by default. */
   reduce: {
     enabled: boolean;

--- a/app/(v2)/store/optimizeStore.ts
+++ b/app/(v2)/store/optimizeStore.ts
@@ -11,6 +11,10 @@ export interface OptimizeSettings {
   /** prune unused data + dedup (safe, applied by default). */
   pruneDedup: boolean;
   textureMaxSize: TextureMaxSize;
+  /** "個別で設定する": drive downscaling per texture instead of the global max. */
+  perTexture: boolean;
+  /** texture name → target max edge (px). Absence means "変更なし" (keep). */
+  textureOverrides: Record<string, number>;
   /** Polygon reduction — OFF by default; requires explicit user action. */
   reduce: {
     enabled: boolean;
@@ -38,6 +42,8 @@ export interface OptimizeResult {
 const DEFAULT_SETTINGS: OptimizeSettings = {
   pruneDedup: true,
   textureMaxSize: 1024, // recommended default
+  perTexture: false,
+  textureOverrides: {},
   reduce: { enabled: false, ratio: 0.5 },
 };
 
@@ -47,6 +53,8 @@ interface OptimizeState {
   estimate: OptimizeEstimate | null;
   result: OptimizeResult | null;
   setSettings: (patch: Partial<OptimizeSettings>) => void;
+  /** Set (or, with `null`, clear back to "変更なし") one texture's target edge. */
+  setTextureOverride: (name: string, target: number | null) => void;
   setStatus: (status: OptimizeStatus) => void;
   setEstimate: (estimate: OptimizeEstimate | null) => void;
   setResult: (result: OptimizeResult | null) => void;
@@ -63,6 +71,20 @@ export const useOptimizeStore = create<OptimizeState>()(
       result: null,
       setSettings: (patch) =>
         set((state) => ({ settings: { ...state.settings, ...patch } }), false, "setSettings"),
+      setTextureOverride: (name, target) =>
+        set(
+          (state) => {
+            const textureOverrides = { ...state.settings.textureOverrides };
+            if (target == null) {
+              delete textureOverrides[name];
+            } else {
+              textureOverrides[name] = target;
+            }
+            return { settings: { ...state.settings, textureOverrides } };
+          },
+          false,
+          "setTextureOverride"
+        ),
       setStatus: (status) => set({ status }, false, "setStatus"),
       setEstimate: (estimate) => set({ estimate }, false, "setEstimate"),
       setResult: (result) => set({ result }, false, "setResult"),

--- a/app/(v2)/store/optimizeStore.ts
+++ b/app/(v2)/store/optimizeStore.ts
@@ -15,6 +15,8 @@ export interface OptimizeSettings {
   perTexture: boolean;
   /** texture name → target max edge (px). Absence means "変更なし" (keep). */
   textureOverrides: Record<string, number>;
+  /** Textures (by name) marked for deletion — non-destructive/undoable. */
+  deletedTextures: string[];
   /** Polygon reduction — OFF by default; requires explicit user action. */
   reduce: {
     enabled: boolean;
@@ -44,6 +46,7 @@ const DEFAULT_SETTINGS: OptimizeSettings = {
   textureMaxSize: 1024, // recommended default
   perTexture: false,
   textureOverrides: {},
+  deletedTextures: [],
   reduce: { enabled: false, ratio: 0.5 },
 };
 
@@ -55,6 +58,8 @@ interface OptimizeState {
   setSettings: (patch: Partial<OptimizeSettings>) => void;
   /** Set (or, with `null`, clear back to "変更なし") one texture's target edge. */
   setTextureOverride: (name: string, target: number | null) => void;
+  /** Toggle a texture's deletion (non-destructive, undoable). */
+  toggleTextureDeleted: (name: string) => void;
   setStatus: (status: OptimizeStatus) => void;
   setEstimate: (estimate: OptimizeEstimate | null) => void;
   setResult: (result: OptimizeResult | null) => void;
@@ -84,6 +89,18 @@ export const useOptimizeStore = create<OptimizeState>()(
           },
           false,
           "setTextureOverride"
+        ),
+      toggleTextureDeleted: (name) =>
+        set(
+          (state) => {
+            const list = state.settings.deletedTextures;
+            const deletedTextures = list.includes(name)
+              ? list.filter((entry) => entry !== name)
+              : [...list, name];
+            return { settings: { ...state.settings, deletedTextures } };
+          },
+          false,
+          "toggleTextureDeleted"
         ),
       setStatus: (status) => set({ status }, false, "setStatus"),
       setEstimate: (estimate) => set({ estimate }, false, "setEstimate"),

--- a/app/(v2)/styles/tokens.scss
+++ b/app/(v2)/styles/tokens.scss
@@ -10,6 +10,7 @@
   --color-on-accent: #ffffff; // text/icon on an accent fill
   --color-highlight: #2f6bff; // Figma color/blue-8 — upload icon, notes, focus
   --color-highlight-soft: #eaf0ff; // Figma color/blue-2 — selected row background
+  --color-danger: #e5484d; // destructive action (texture delete)
 
   // Surface & text ramp (light)
   --color-bg: #f7f5f2; // Figma color/biege-3
@@ -60,6 +61,7 @@
   --color-accent-strong: #ff6a3d;
   --color-accent-soft: #3a2a22;
   --color-highlight: #6f9bff;
+  --color-danger: #f2555a;
 
   --color-bg: #1b1a18;
   --color-viewer-bg: #1b1a18; // dark: unchanged (matches the app background)


### PR DESCRIPTION
## 概要

軽量化タブ「テクスチャの最適化」に**個別テクスチャ解像度設定**（Figma node 78-362）を実装。#35 で保留していたデザインで、頂いたスクリーンショットに準拠。

`☑ 個別で設定する` をオンにすると、全体の解像度チップの代わりにテクスチャ一覧（サムネイル・マップ種別・ファイル名・寸法・サイズ）を表示し、各テクスチャに解像度ドロップダウン（`変更なし` ＋ 有効なダウンスケール、`1024（おすすめ）`）を提供する。

## 変更点

- **optimizeStore / types**: `perTexture` ＋ `textureOverrides`（テクスチャ名→目標エッジ px）設定と `setTextureOverride` アクションを追加。既定はオフ/空で、リセットで復帰。
- **Worker**: `downscaleTextures` が settings を受け取り、個別モードでは各テクスチャの override（名前でキー、無ければ「変更なし」）を、通常モードでは従来通りグローバル最大値を使用。
- **TextureOptimizeCard**: ビューアが解析したマテリアルからテクスチャ一覧をユニーク化して構築。個別モード有効化時は「推奨1024を超えるものは1024へ、それ以外は変更なし」を初期値として自動シード。

テクスチャ管理は軽量化タブに集約（プレビューは閲覧専用のまま）。

## QA (Playwright MCP, port 3100, test2.glb)

- ✅ 18テクスチャを寸法・サイズ付きで一覧表示。ダウンスケール不可（≤512）の行はドロップダウンを disabled。
- ✅ 既定シード: 2048テクスチャ→`1024（おすすめ）`、それ以外→`変更なし`。
- ✅ **個別反映＋名前マッチング**: あるテクスチャ(1024)を512に変更→サマリ -15%→-21%(10.2→9.4MB)。保存 glb で当該テクスチャのみ 512×512、`変更なし` の 1024 テクスチャは 1024×1024 のまま。
- ✅ チェックを外すとグローバルチップ(1024)に復帰し -15% に戻る。
- ✅ console エラー 0 件。`/legacy` 200。lint / test(48 passed) / build 全パス。

## 関連

- Figma node 78-362（#35 で保留していた個別テクスチャ指定）
- プレビュー側のマテリアル/テクスチャ削除UI(旧 #38 / PR #52)は「プレビューは閲覧専用」の方針に基づき却下。#52 はクローズ予定。