### PR TITLE
Move the /legacy link to the sidebar bottom (1-9)

### DIFF
--- a/app/(v2)/components/Header.module.scss
+++ b/app/(v2)/components/Header.module.scss
@@ -128,15 +128,3 @@
   font-size: var(--font-size-11);
   line-height: 14px;
 }
-
-.legacyLink {
-  font-size: var(--font-size-11);
-  line-height: 14px;
-  color: var(--color-text-faint);
-  text-decoration: underline;
-  text-underline-offset: 2px;
-
-  &:hover {
-    color: var(--color-accent);
-  }
-}

--- a/app/(v2)/components/Header.tsx
+++ b/app/(v2)/components/Header.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useUiStore, type Mode } from "../store/uiStore";
 import {
   RocketIcon,
@@ -67,9 +66,6 @@ export function Header() {
         </button>
         <span className={styles.meta}>
           <span className={styles.version}>v2.0</span>
-          <Link className={styles.legacyLink} href="/legacy">
-            Previous version
-          </Link>
         </span>
       </div>
     </header>

--- a/app/(v2)/components/LegacyLink.module.scss
+++ b/app/(v2)/components/LegacyLink.module.scss
@@ -1,0 +1,15 @@
+.link {
+  align-self: flex-start;
+  // Push the link to the bottom of the sidebar column, below every card.
+  margin-top: auto;
+  padding-top: var(--space-8);
+  color: var(--color-text-faint);
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+
+  &:hover {
+    color: var(--color-accent);
+  }
+}

--- a/app/(v2)/components/LegacyLink.tsx
+++ b/app/(v2)/components/LegacyLink.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+import styles from "./LegacyLink.module.scss";
+
+/**
+ * Discreet link to the frozen legacy app (F-21). Sits at the bottom of the
+ * sidebar, below the cards, so it never competes with the main flow.
+ */
+export function LegacyLink() {
+  return (
+    <Link className={styles.link} href="/legacy">
+      以前のバージョンを開く
+    </Link>
+  );
+}

--- a/app/(v2)/features/preview/ModelWorkspace.tsx
+++ b/app/(v2)/features/preview/ModelWorkspace.tsx
@@ -7,6 +7,7 @@ import { useThreeStage } from "../../viewer/useThreeStage";
 import { Stage } from "../../viewer/Stage";
 import { FileDropzone } from "../../components/FileDropzone";
 import { Copyright } from "../../components/Copyright";
+import { LegacyLink } from "../../components/LegacyLink";
 import { PreviewSidebar } from "./PreviewSidebar";
 import { OptimizeSidebar } from "../optimize/OptimizeSidebar";
 import styles from "../../styles/page.module.scss";
@@ -33,6 +34,9 @@ export function ModelWorkspace() {
           <>
             <FileDropzone />
             <PreviewSidebar stage={stage} />
+            {/* Optimize mode's bottom is the save CTA; keep the discreet legacy
+                link to preview/empty so it never competes with the main flow. */}
+            <LegacyLink />
           </>
         )}
       </aside>

--- a/app/(v2)/page.tsx
+++ b/app/(v2)/page.tsx
@@ -5,6 +5,7 @@ import { Header } from "./components/Header";
 import { ServiceInfo } from "./components/ServiceInfo";
 import { FileDropzone } from "./components/FileDropzone";
 import { Copyright } from "./components/Copyright";
+import { LegacyLink } from "./components/LegacyLink";
 import { ModelWorkspace } from "./features/preview/ModelWorkspace";
 import styles from "./styles/page.module.scss";
 
@@ -25,6 +26,7 @@ export default function V2Page() {
           <>
             <aside className={styles.sidebar}>
               <ServiceInfo />
+              <LegacyLink />
             </aside>
             <section className={styles.viewer} aria-label="3Dビュー">
               <div className={styles.viewerBody}>


### PR DESCRIPTION
## 概要

新版から `/legacy` への導線（F-21）を、ヘッダー右上からサイドバー下部へ移動する（issue 1-9）。

## 変更点

- **LegacyLink**（新規コンポーネント）: 控えめな「以前のバージョンを開く」リンク。`margin-top: auto` でサイドバー最下部（カードの下）に固定。
- **Header**: 右上メタから legacy リンクを撤去（`v2.0` は残置）。未使用になった `Link` import と `.legacyLink` スタイルも削除。
- **配置**: 空状態・プレビュー状態のサイドバー下部に表示。軽量化モードの下部は保存CTA（軽量化して保存）が占めるため、主動線を妨げないようそこには置かない。

## QA (Playwright MCP, port 3100)

- ✅ 空状態・プレビュー状態のサイドバー最下部に控えめなリンクを表示。
- ✅ リンククリックで `/legacy` に遷移し、旧アプリが正常表示。
- ✅ ヘッダーは `v2.0` のみ（リンク撤去）。
- ✅ console エラー 0 件。lint / test(48 passed) / build 全パス。

Closes #39