### PR TITLE
Hide mode tabs until upload; remove v2.0; confirm theme persistence

### DIFF
--- a/app/(v2)/components/Header.module.scss
+++ b/app/(v2)/components/Header.module.scss
@@ -116,15 +116,3 @@
     background: var(--color-track);
   }
 }
-
-.meta {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  color: var(--color-text-faint);
-}
-
-.version {
-  font-size: var(--font-size-11);
-  line-height: 14px;
-}

--- a/app/(v2)/components/Header.tsx
+++ b/app/(v2)/components/Header.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useModelStore } from "../store/modelStore";
 import { useUiStore, type Mode } from "../store/uiStore";
 import {
   RocketIcon,
@@ -17,6 +18,7 @@ const MODE_TABS: { value: Mode; label: string; Icon: (props: IconProps) => React
 ];
 
 export function Header() {
+  const hasModel = useModelStore((state) => state.originalBytes !== null);
   const mode = useUiStore((state) => state.mode);
   const setMode = useUiStore((state) => state.setMode);
   const theme = useUiStore((state) => state.theme);
@@ -34,25 +36,28 @@ export function Header() {
         </span>
       </div>
 
+      {/* Mode tabs only make sense once a model is loaded. */}
       <div className={styles.center}>
-        <div className={styles.modeTabs} role="tablist" aria-label="表示モード">
-          {MODE_TABS.map(({ value, label, Icon }) => {
-            const isActive = mode === value;
-            return (
-              <button
-                key={value}
-                type="button"
-                role="tab"
-                aria-selected={isActive}
-                className={`${styles.modeTab} ${isActive ? styles.modeTabActive : ""}`}
-                onClick={() => setMode(value)}
-              >
-                <Icon size={14} />
-                {label}
-              </button>
-            );
-          })}
-        </div>
+        {hasModel && (
+          <div className={styles.modeTabs} role="tablist" aria-label="表示モード">
+            {MODE_TABS.map(({ value, label, Icon }) => {
+              const isActive = mode === value;
+              return (
+                <button
+                  key={value}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  className={`${styles.modeTab} ${isActive ? styles.modeTabActive : ""}`}
+                  onClick={() => setMode(value)}
+                >
+                  <Icon size={14} />
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        )}
       </div>
 
       <div className={styles.right}>
@@ -64,9 +69,6 @@ export function Header() {
         >
           {theme === "light" ? <MoonIcon size={16} /> : <SunIcon size={16} />}
         </button>
-        <span className={styles.meta}>
-          <span className={styles.version}>v2.0</span>
-        </span>
       </div>
     </header>
   );


### PR DESCRIPTION
## 概要

ヘッダーの調整3点:

1. **モデル未アップロード時はプレビュー/軽量化タブを非表示**（切り替える対象がまだ無いため）。アップロード後に表示。
2. **右側の「v2.0」表記を削除**（未使用の `.meta`/`.version` スタイルも撤去）。
3. **ダーク/ライトのテーマ切替をブラウザに記録**（リロード・次回アクセスでも継承）。→ `uiStore` の persist ミドルウェア + `AppShell` の rehydrate で既に実装済みであることを実測確認。

## QA (Playwright MCP, port 3100)

- ✅ 空状態: モードタブなし・v2.0 なし、テーマトグルのみ表示。
- ✅ モデルをアップロード → プレビュー/軽量化タブが出現。
- ✅ ダークモードに切替 → localStorage に保存され、**リロード後も dark を継承**（data-theme=dark 復元）。
- ✅ console エラー 0 件。lint / test(48 passed) / build 全パス。