### PR TITLE
Fix dropzone hover color; drag & drop on the viewer area

### DIFF
--- a/app/(v2)/components/FileDropzone.module.scss
+++ b/app/(v2)/components/FileDropzone.module.scss
@@ -30,9 +30,11 @@
   transition: border-color 0.15s ease, background-color 0.15s ease;
 
   &:hover,
+  &:focus-visible,
   &.dragging {
     border-color: var(--color-highlight);
-    background: var(--color-bg);
+    background: var(--color-highlight-soft);
+    outline: none;
   }
 }
 

--- a/app/(v2)/components/FileDropzone.tsx
+++ b/app/(v2)/components/FileDropzone.tsx
@@ -26,11 +26,14 @@ export function FileDropzone({ variant = "panel" }: FileDropzoneProps) {
         onClick={() => inputRef.current?.click()}
         onDragOver={(event) => {
           event.preventDefault();
+          event.stopPropagation();
           setIsDragging(true);
         }}
         onDragLeave={() => setIsDragging(false)}
         onDrop={(event) => {
           event.preventDefault();
+          // Handle here; don't also trigger the viewer-area drop target.
+          event.stopPropagation();
           setIsDragging(false);
           void acceptFiles(event.dataTransfer.files);
         }}

--- a/app/(v2)/features/preview/ModelWorkspace.tsx
+++ b/app/(v2)/features/preview/ModelWorkspace.tsx
@@ -3,6 +3,7 @@
 import { useModelStore } from "../../store/modelStore";
 import { useUiStore } from "../../store/uiStore";
 import { useOptimizeStore } from "../../store/optimizeStore";
+import { useViewerDrop } from "../../hooks/useViewerDrop";
 import { useThreeStage } from "../../viewer/useThreeStage";
 import { Stage } from "../../viewer/Stage";
 import { FileDropzone } from "../../components/FileDropzone";
@@ -24,6 +25,7 @@ export function ModelWorkspace() {
   // result"); everywhere else render the original.
   const displayBytes = mode === "optimize" && resultBytes ? resultBytes : bytes;
   const stage = useThreeStage(displayBytes, bytes);
+  const { isDragging, dropProps } = useViewerDrop();
 
   return (
     <>
@@ -40,7 +42,7 @@ export function ModelWorkspace() {
           </>
         )}
       </aside>
-      <section className={styles.viewer} aria-label="3Dビュー">
+      <section className={styles.viewer} aria-label="3Dビュー" {...dropProps}>
         <Stage
           containerRef={stage.containerRef}
           onPointerDown={stage.onPointerDown}
@@ -51,6 +53,7 @@ export function ModelWorkspace() {
           onResetView={stage.resetView}
         />
         <Copyright />
+        {isDragging && <div className={styles.dropOverlay}>ここに .glb をドロップして差し替え</div>}
       </section>
     </>
   );

--- a/app/(v2)/hooks/useViewerDrop.ts
+++ b/app/(v2)/hooks/useViewerDrop.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useModelUpload } from "./useModelUpload";
+
+/**
+ * Drag & drop a `.glb` anywhere on the viewer area to load it (F: upload from
+ * the 3D view). Returns the drag state (for a drop overlay) and the handlers to
+ * spread onto the viewer container.
+ */
+export function useViewerDrop() {
+  const { acceptFiles } = useModelUpload();
+  const [isDragging, setIsDragging] = useState(false);
+
+  const onDragOver = useCallback((event: React.DragEvent) => {
+    if (!event.dataTransfer.types.includes("Files")) {
+      return;
+    }
+    event.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const onDragLeave = useCallback((event: React.DragEvent) => {
+    // Ignore leave events fired when moving between child elements.
+    if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      return;
+    }
+    setIsDragging(false);
+  }, []);
+
+  const onDrop = useCallback(
+    (event: React.DragEvent) => {
+      event.preventDefault();
+      setIsDragging(false);
+      void acceptFiles(event.dataTransfer.files);
+    },
+    [acceptFiles]
+  );
+
+  return { isDragging, dropProps: { onDragOver, onDragLeave, onDrop } };
+}

--- a/app/(v2)/page.tsx
+++ b/app/(v2)/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useModelStore } from "./store/modelStore";
+import { useViewerDrop } from "./hooks/useViewerDrop";
 import { Header } from "./components/Header";
 import { ServiceInfo } from "./components/ServiceInfo";
 import { FileDropzone } from "./components/FileDropzone";
@@ -15,6 +16,7 @@ import styles from "./styles/page.module.scss";
  */
 export default function V2Page() {
   const hasModel = useModelStore((state) => state.originalBytes !== null);
+  const { isDragging, dropProps } = useViewerDrop();
 
   return (
     <>
@@ -28,11 +30,12 @@ export default function V2Page() {
               <ServiceInfo />
               <LegacyLink />
             </aside>
-            <section className={styles.viewer} aria-label="3Dビュー">
+            <section className={styles.viewer} aria-label="3Dビュー" {...dropProps}>
               <div className={styles.viewerBody}>
                 <FileDropzone variant="hero" />
               </div>
               <Copyright />
+              {isDragging && <div className={styles.dropOverlay}>ここに .glb をドロップ</div>}
             </section>
           </>
         )}

--- a/app/(v2)/styles/page.module.scss
+++ b/app/(v2)/styles/page.module.scss
@@ -17,10 +17,30 @@
 }
 
 .viewer {
+  position: relative;
   flex: 1;
   display: flex;
   flex-direction: column;
   min-width: 0;
+}
+
+// Shown while a file is dragged over the viewer area (drag & drop to upload).
+.dropOverlay {
+  position: absolute;
+  inset: var(--space-12);
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-8);
+  border: 2px dashed var(--color-highlight);
+  border-radius: var(--radius-md);
+  background: var(--color-highlight-soft);
+  color: var(--color-highlight);
+  font-weight: 600;
+  font-size: var(--font-size-16);
+  line-height: 20px;
+  pointer-events: none;
 }
 
 .viewerBody {


### PR DESCRIPTION
## 概要

2点対応:

1. **ファイルアップローダーのホバー/フォーカス色**を、添付デザイン通りの青系（`--color-highlight-soft` の淡い青地 + 青の破線ボーダー）に修正（従来はベージュ地だった）。
2. **右側のビューエリアへのドラッグ&ドロップでアップロード**可能に。空状態・モデル読込済みの両方でビューエリア全体がドロップ対象になり、ドラッグ中はオーバーレイを表示。読込済み状態でドロップするとモデルを差し替え。

## 変更点

- **FileDropzone**: hover/focus/drag の背景を `--color-highlight-soft` に。ドラッグイベントで `stopPropagation`（ビューエリアのドロップと二重発火しないように）。
- **useViewerDrop**（新規フック）: ビューエリアへの `.glb` ドロップを処理。
- **page.tsx / ModelWorkspace**: ビューの `<section>` をドロップ対象化し、ドラッグ中オーバーレイを表示。

## QA (Playwright MCP, port 3100)

- ✅ ドロップゾーンのホバーで青地＋青破線に（デザイン一致）。
- ✅ ビューエリアに `.glb` をドラッグ → オーバーレイ表示、ドロップで実際にモデルが読み込まれる（実ファイルの合成ドロップでエンドツーエンド確認：`dropped.glb` が読み込まれ3D表示）。
- ✅ 読込済み状態でも「ここに .glb をドロップして差し替え」オーバーレイ表示。
- ✅ console エラー 0 件。lint / test(48 passed) / build 全パス。