### PR TITLE
GA4 利用状況計測(アップロード/軽量化操作/設定/削減率)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Google Analytics 4 measurement ID. When unset, GA is not loaded and no events
+# are sent (local/test builds stay silent). Set in production to enable
+# page_view (both / and /legacy) + v2 custom interaction events.
+NEXT_PUBLIC_GA_MEASUREMENT_ID=

--- a/app/(v2)/components/FileDropzone.tsx
+++ b/app/(v2)/components/FileDropzone.tsx
@@ -35,7 +35,7 @@ export function FileDropzone({ variant = "panel" }: FileDropzoneProps) {
           // Handle here; don't also trigger the viewer-area drop target.
           event.stopPropagation();
           setIsDragging(false);
-          void acceptFiles(event.dataTransfer.files);
+          void acceptFiles(event.dataTransfer.files, "drop");
         }}
       >
         <input
@@ -43,7 +43,7 @@ export function FileDropzone({ variant = "panel" }: FileDropzoneProps) {
           type="file"
           accept=".glb"
           hidden
-          onChange={(event) => void acceptFiles(event.target.files)}
+          onChange={(event) => void acceptFiles(event.target.files, "click")}
         />
         <span className={styles.icon}>
           <UploadIcon size={24} />

--- a/app/(v2)/components/Header.tsx
+++ b/app/(v2)/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import { useModelStore } from "../store/modelStore";
 import { useUiStore, type Mode } from "../store/uiStore";
+import { analytics } from "../lib/analytics";
 import {
   RocketIcon,
   EyeIcon,
@@ -49,7 +50,12 @@ export function Header() {
                   role="tab"
                   aria-selected={isActive}
                   className={`${styles.modeTab} ${isActive ? styles.modeTabActive : ""}`}
-                  onClick={() => setMode(value)}
+                  onClick={() => {
+                    if (value === "optimize") {
+                      analytics.optimizeTabOpen();
+                    }
+                    setMode(value);
+                  }}
                 >
                   <Icon size={14} />
                   {label}

--- a/app/(v2)/components/ModelSummaryCard.tsx
+++ b/app/(v2)/components/ModelSummaryCard.tsx
@@ -3,6 +3,7 @@
 import { useModelStore } from "../store/modelStore";
 import { useUiStore } from "../store/uiStore";
 import { formatFileSize } from "../lib/formatFileSize";
+import { analytics } from "../lib/analytics";
 import { FileIcon, ZapIcon, ArrowRightIcon } from "../icons";
 import styles from "./ModelSummaryCard.module.scss";
 
@@ -45,7 +46,14 @@ export function ModelSummaryCard() {
         </div>
       </div>
 
-      <button type="button" className={styles.cta} onClick={() => setMode("optimize")}>
+      <button
+        type="button"
+        className={styles.cta}
+        onClick={() => {
+          analytics.optimizeCtaClick("preview_summary");
+          setMode("optimize");
+        }}
+      >
         <ZapIcon size={16} />
         <span className={styles.ctaLabel}>モデルの軽量化をする</span>
         <ArrowRightIcon size={16} />

--- a/app/(v2)/features/optimize/BeforeAfterSummary.tsx
+++ b/app/(v2)/features/optimize/BeforeAfterSummary.tsx
@@ -3,7 +3,10 @@
 import { useModelStore } from "../../store/modelStore";
 import { useOptimizeStore } from "../../store/optimizeStore";
 import { formatFileSize } from "../../lib/formatFileSize";
+import { analytics } from "../../lib/analytics";
 import { DownloadIcon } from "../../icons";
+
+const bytesToMb = (bytes: number) => +(bytes / 1024 / 1024).toFixed(2);
 import styles from "./BeforeAfterSummary.module.scss";
 
 /** Turn "test2.glb" into "test2_optimized.glb". */
@@ -23,6 +26,7 @@ export function BeforeAfterSummary() {
   const status = useOptimizeStore((state) => state.status);
   const estimate = useOptimizeStore((state) => state.estimate);
   const resultBytes = useOptimizeStore((state) => state.result?.bytes);
+  const settings = useOptimizeStore((state) => state.settings);
 
   const ready = status === "ready" && estimate != null;
 
@@ -37,6 +41,18 @@ export function BeforeAfterSummary() {
     link.download = optimizedName(name);
     link.click();
     URL.revokeObjectURL(url);
+
+    // Capture the export: reduction achieved + which settings were enabled.
+    analytics.modelExport({
+      reduction_pct: estimate?.deltaPct ?? 0,
+      before_mb: bytesToMb(originalSize),
+      after_mb: bytesToMb(estimate?.afterBytes ?? 0),
+      prune_dedup: settings.pruneDedup,
+      texture_optimize: settings.textureMaxSize !== "off",
+      texture_per_texture: settings.perTexture,
+      polygon_reduce: settings.reduce.enabled,
+      texture_delete_count: settings.deletedTextures.length,
+    });
   };
 
   return (

--- a/app/(v2)/features/preview/MaterialTab.tsx
+++ b/app/(v2)/features/preview/MaterialTab.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { StageController } from "../../viewer/useThreeStage";
 import { useUiStore } from "../../store/uiStore";
 import { formatFileSize } from "../../lib/formatFileSize";
+import { analytics } from "../../lib/analytics";
 import { SphereIcon, ZapIcon, ArrowRightIcon } from "../../icons";
 import { TabCard } from "./TabCard";
 import styles from "./MaterialTab.module.scss";
@@ -94,7 +95,14 @@ export function MaterialTab({ stage }: { stage: StageController }) {
         })}
       </ul>
 
-      <button type="button" className={styles.cta} onClick={() => setMode("optimize")}>
+      <button
+        type="button"
+        className={styles.cta}
+        onClick={() => {
+          analytics.optimizeCtaClick("material_tab");
+          setMode("optimize");
+        }}
+      >
         <ZapIcon size={16} />
         <span className={styles.ctaLabel}>マテリアルの最適化をする</span>
         <ArrowRightIcon size={16} />

--- a/app/(v2)/hooks/useModelUpload.ts
+++ b/app/(v2)/hooks/useModelUpload.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import { useModelStore } from "../store/modelStore";
 import { useUiStore } from "../store/uiStore";
+import { analytics } from "../lib/analytics";
 
 const GLB_EXTENSION = ".glb";
 
@@ -15,7 +16,7 @@ export function useModelUpload() {
   const [error, setError] = useState<string | null>(null);
 
   const acceptFiles = useCallback(
-    async (files: FileList | File[] | null) => {
+    async (files: FileList | File[] | null, source: "click" | "drop" = "click") => {
       const file = files && files[0];
       if (!file) {
         return;
@@ -27,6 +28,7 @@ export function useModelUpload() {
       setError(null);
       const originalBytes = await file.arrayBuffer();
       loadModel(originalBytes, { name: file.name, size: file.size });
+      analytics.modelUpload(source, +(file.size / 1024 / 1024).toFixed(2));
       // Always land a freshly uploaded model in preview, even if the persisted
       // mode was "optimize" from a previous session.
       setMode("preview");

--- a/app/(v2)/hooks/useViewerDrop.ts
+++ b/app/(v2)/hooks/useViewerDrop.ts
@@ -32,7 +32,7 @@ export function useViewerDrop() {
     (event: React.DragEvent) => {
       event.preventDefault();
       setIsDragging(false);
-      void acceptFiles(event.dataTransfer.files);
+      void acceptFiles(event.dataTransfer.files, "drop");
     },
     [acceptFiles]
   );

--- a/app/(v2)/lib/analytics.ts
+++ b/app/(v2)/lib/analytics.ts
@@ -1,0 +1,39 @@
+import { sendGAEvent } from "@next/third-parties/google";
+
+/**
+ * GA4 custom events for v2 (client-side only). Access counts use the automatic
+ * `page_view` event (wired via the root `<GoogleAnalytics>` tag); these are the
+ * interaction events. All params are anonymous — never the model's bytes,
+ * content, or filename. No-op unless `NEXT_PUBLIC_GA_MEASUREMENT_ID` is set.
+ */
+const GA_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+
+type Params = Record<string, string | number | boolean>;
+
+function track(event: string, params?: Params): void {
+  if (!GA_ID || typeof window === "undefined") {
+    return;
+  }
+  sendGAEvent("event", event, params ?? {});
+}
+
+/** Params for `model_export`, captured from the settings at save time. */
+export interface ModelExportParams {
+  reduction_pct: number;
+  before_mb: number;
+  after_mb: number;
+  prune_dedup: boolean;
+  texture_optimize: boolean;
+  texture_per_texture: boolean;
+  polygon_reduce: boolean;
+  texture_delete_count: number;
+}
+
+export const analytics = {
+  modelUpload: (method: "click" | "drop", fileSizeMb: number) =>
+    track("model_upload", { method, file_size_mb: fileSizeMb }),
+  optimizeTabOpen: () => track("optimize_tab_open"),
+  optimizeCtaClick: (location: "preview_summary" | "material_tab") =>
+    track("optimize_cta_click", { location }),
+  modelExport: (params: ModelExportParams) => track("model_export", { ...params }),
+};

--- a/app/Analytics.tsx
+++ b/app/Analytics.tsx
@@ -1,0 +1,23 @@
+import { GoogleAnalytics } from "@next/third-parties/google";
+import { PageViewTracker } from "./PageViewTracker";
+
+/**
+ * Root GA4 tag. Placed in the root layout so `page_view` is collected for both
+ * `/` (v2) and `/legacy` — differentiated by `page_path`. The GA config only
+ * fires the initial page_view, so `PageViewTracker` adds one per client-side
+ * route change. Custom interaction events fire only from v2 code. Renders
+ * nothing (and sends nothing) unless `NEXT_PUBLIC_GA_MEASUREMENT_ID` is set, so
+ * local/test builds stay silent.
+ */
+export function Analytics() {
+  const gaId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+  if (!gaId) {
+    return null;
+  }
+  return (
+    <>
+      <GoogleAnalytics gaId={gaId} />
+      <PageViewTracker />
+    </>
+  );
+}

--- a/app/PageViewTracker.tsx
+++ b/app/PageViewTracker.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useRef } from "react";
+import { sendGAEvent } from "@next/third-parties/google";
+
+/**
+ * Sends a `page_view` on client-side route changes. The GA config only fires the
+ * initial page_view, so without this an in-app navigation (e.g. `/` → `/legacy`)
+ * would not be counted. The first render is skipped to avoid double-counting the
+ * initial view.
+ */
+export function PageViewTracker() {
+  const pathname = usePathname();
+  const isInitial = useRef(true);
+
+  useEffect(() => {
+    if (isInitial.current) {
+      isInitial.current = false;
+      return;
+    }
+    sendGAEvent("event", "page_view", {
+      page_path: pathname,
+      page_location: window.location.href,
+      page_title: document.title,
+    });
+  }, [pathname]);
+
+  return null;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 // lib
 import type { Metadata } from "next";
 import { Sometype_Mono } from "next/font/google";
+import { Analytics } from "./Analytics";
 
 const sometypeMono = Sometype_Mono({
   subsets: ["latin"],
@@ -20,6 +21,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={sometypeMono.variable}>
       <body>{children}</body>
+      <Analytics />
     </html>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@gltf-transform/core": "^4.4.1",
         "@gltf-transform/functions": "^4.4.1",
+        "@next/third-parties": "^14.2.35",
         "@vercel/analytics": "^1.5.0",
         "meshoptimizer": "^1.2.0",
         "next": "14.2.35",
@@ -1757,6 +1758,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-14.2.35.tgz",
+      "integrity": "sha512-dG1J+4uYungW1snGViN7tAVyfO0iz0zoB+sqsLMUo8kwR0NED2muLTMbOChmrliHhzOFj6ZpHfkvhy5NJjFvSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0",
+        "react": "^18.2.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7221,6 +7235,12 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/three": {
       "version": "0.167.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@gltf-transform/core": "^4.4.1",
     "@gltf-transform/functions": "^4.4.1",
+    "@next/third-parties": "^14.2.35",
     "@vercel/analytics": "^1.5.0",
     "meshoptimizer": "^1.2.0",
     "next": "14.2.35",


### PR DESCRIPTION
## 概要

issue #58 の実装。GA4 でクライアントサイド計測を導入する。

## 変更点

- **root layout**: `@next/third-parties/google` の `<GoogleAnalytics>` ＋ `PageViewTracker` を設置。`/`(v2) と `/legacy` 双方で `page_view` を計測（`page_path` で区別）。GA config は初回のみ page_view を送るため、`PageViewTracker` がルート変更ごとに page_view を追加送出（in-app の /legacy 遷移も計測）。
- **`app/(v2)/lib/analytics.ts`**: `sendGAEvent` の薄いラッパ。`NEXT_PUBLIC_GA_MEASUREMENT_ID` 未設定時は完全 no-op。送るのは匿名の数値/真偽値/区分のみ（モデルの中身・ファイル名は送らない）。
- **カスタムイベント（v2 のみ）**:
  - `model_upload` `{method, file_size_mb}` … `useModelUpload` の一点（クリック/ドロップ/ビューD&D を網羅）
  - `optimize_tab_open` … ヘッダー「軽量化」タブ
  - `optimize_cta_click` `{location: preview_summary | material_tab}` … オレンジの2ボタン
  - `model_export` `{reduction_pct, before_mb, after_mb, prune_dedup, texture_optimize, texture_per_texture, polygon_reduce, texture_delete_count}` … 保存時（③各設定の有効化＋④削減率）

## QA (Playwright MCP, port 3100, テストID)

- ✅ 5種のカスタムイベントが正しいパラメータで発火（`model_upload`/`optimize_tab_open`/`optimize_cta_click`×2/`model_export`）。
- ✅ `/legacy` への in-app 遷移で `page_view`(`page_path=/legacy`) を送出。
- ✅ `NEXT_PUBLIC_GA_MEASUREMENT_ID` 未設定時は gtag/dataLayer/スクリプトが一切無い（サイレント）。
- ✅ legacy からはカスタムイベントを発火しない（v2 コードからのみ）。console エラー 0 / lint・test(48)・build 全パス。

## マージ後に必要な設定（別途報告）

- `NEXT_PUBLIC_GA_MEASUREMENT_ID` の本番設定
- GA4 のカスタムディメンション/指標の登録（レポートで参照するため）
- Enhanced Measurement の「履歴イベントに基づくページ変更」の扱い（二重計測回避）

Closes #58