### PR TITLE
プレビューにキャプチャ機能を追加(ライト/影/背景透過)

### DIFF
--- a/app/(v2)/features/preview/ModelWorkspace.tsx
+++ b/app/(v2)/features/preview/ModelWorkspace.tsx
@@ -6,6 +6,7 @@ import { useOptimizeStore } from "../../store/optimizeStore";
 import { useViewerDrop } from "../../hooks/useViewerDrop";
 import { useThreeStage } from "../../viewer/useThreeStage";
 import { Stage } from "../../viewer/Stage";
+import { CapturePanel } from "../../viewer/CapturePanel";
 import { FileDropzone } from "../../components/FileDropzone";
 import { Copyright } from "../../components/Copyright";
 import { LegacyLink } from "../../components/LegacyLink";
@@ -53,6 +54,7 @@ export function ModelWorkspace() {
           onResetView={stage.resetView}
         />
         <Copyright />
+        {mode === "preview" && <CapturePanel stage={stage} />}
         {isDragging && <div className={styles.dropOverlay}>ここに .glb をドロップして差し替え</div>}
       </section>
     </>

--- a/app/(v2)/viewer/CapturePanel.module.scss
+++ b/app/(v2)/viewer/CapturePanel.module.scss
@@ -12,14 +12,17 @@
 .trigger {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 32px;
+  gap: var(--space-4);
   height: 32px;
-  padding: 0;
+  padding: 0 var(--space-12);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-pill);
   background: var(--color-surface);
   color: var(--color-text-muted);
+  font-family: inherit;
+  font-weight: 600;
+  font-size: var(--font-size-14);
+  line-height: 18px;
   box-shadow: var(--shadow-sm);
   cursor: pointer;
   transition: color 0.15s ease, background-color 0.15s ease;
@@ -28,6 +31,10 @@
     color: var(--color-text);
     background: var(--color-track);
   }
+}
+
+.triggerLabel {
+  white-space: nowrap;
 }
 
 .triggerActive {
@@ -68,10 +75,11 @@
   color: var(--color-text-faint);
 }
 
+// Slider — matches the design-system pattern used by PolygonReduceCard.
 .slider {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  gap: var(--space-8);
 }
 
 .sliderHead {
@@ -83,13 +91,55 @@
 }
 
 .value {
+  font-weight: 600;
   color: var(--color-text);
   font-variant-numeric: tabular-nums;
 }
 
-.range {
+.bar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 16px;
+}
+
+.fill {
+  position: absolute;
+  left: 0;
+  height: 6px;
+  border-radius: var(--radius-sm);
+  background: var(--color-highlight);
+}
+
+.bar::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 6px;
+  border-radius: var(--radius-sm);
+  background: var(--color-border);
+}
+
+.knob {
+  position: absolute;
+  z-index: 1;
+  width: 11.2px;
+  height: 11.2px;
+  transform: translateX(-50%);
+  border: 2px solid var(--color-surface);
+  border-radius: var(--radius-pill);
+  background: var(--color-highlight);
+  pointer-events: none;
+}
+
+.input {
+  position: absolute;
+  left: 0;
   width: 100%;
-  accent-color: var(--color-accent);
+  height: 16px;
+  margin: 0;
+  opacity: 0;
   cursor: pointer;
 }
 

--- a/app/(v2)/viewer/CapturePanel.module.scss
+++ b/app/(v2)/viewer/CapturePanel.module.scss
@@ -1,0 +1,152 @@
+.root {
+  position: absolute;
+  top: var(--space-12);
+  right: var(--space-12);
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-8);
+}
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  transition: color 0.15s ease, background-color 0.15s ease;
+
+  &:hover {
+    color: var(--color-text);
+    background: var(--color-track);
+  }
+}
+
+.triggerActive {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+  width: 240px;
+  padding: var(--space-16);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.heading {
+  margin: 0;
+  font-weight: 600;
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  color: var(--color-text);
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+.groupLabel {
+  font-weight: 600;
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-text-faint);
+}
+
+.slider {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.sliderHead {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  color: var(--color-text-muted);
+}
+
+.value {
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.range {
+  width: 100%;
+  accent-color: var(--color-accent);
+  cursor: pointer;
+}
+
+.check {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.checkBox {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border: 1.5px solid var(--color-text-faint);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: transparent;
+}
+
+.checkOn {
+  border-color: var(--color-highlight);
+  background: var(--color-highlight);
+  color: var(--color-on-accent);
+}
+
+.checkLabel {
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  color: var(--color-text);
+}
+
+.capture {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-8);
+  padding: var(--space-12);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  font-family: inherit;
+  font-weight: 600;
+  font-size: var(--font-size-14);
+  line-height: 18px;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background: var(--color-accent-strong);
+  }
+}

--- a/app/(v2)/viewer/CapturePanel.module.scss
+++ b/app/(v2)/viewer/CapturePanel.module.scss
@@ -21,8 +21,8 @@
   color: var(--color-text-muted);
   font-family: inherit;
   font-weight: 600;
-  font-size: var(--font-size-14);
-  line-height: 18px;
+  font-size: var(--font-size-11);
+  line-height: 14px;
   box-shadow: var(--shadow-sm);
   cursor: pointer;
   transition: color 0.15s ease, background-color 0.15s ease;

--- a/app/(v2)/viewer/CapturePanel.tsx
+++ b/app/(v2)/viewer/CapturePanel.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+import type { StageController } from "./useThreeStage";
+import { CameraIcon, CheckIcon } from "../icons";
+import styles from "./CapturePanel.module.scss";
+
+function Slider({
+  label,
+  min,
+  max,
+  step,
+  value,
+  onChange,
+}: {
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <label className={styles.slider}>
+      <span className={styles.sliderHead}>
+        <span>{label}</span>
+        <span className={styles.value}>{value.toFixed(2)}</span>
+      </span>
+      <input
+        type="range"
+        className={styles.range}
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+      />
+    </label>
+  );
+}
+
+function Check({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={styles.check}
+      role="checkbox"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+    >
+      <span className={`${styles.checkBox} ${checked ? styles.checkOn : ""}`}>
+        {checked && <CheckIcon size={10} />}
+      </span>
+      <span className={styles.checkLabel}>{label}</span>
+    </button>
+  );
+}
+
+/**
+ * Capture control (preview only): a camera button at the viewer's top-right that
+ * opens a panel to tune the light + shadow and choose background transparency,
+ * then export the 3D view as a PNG.
+ */
+export function CapturePanel({ stage }: { stage: StageController }) {
+  const [open, setOpen] = useState(false);
+  const [transparent, setTransparent] = useState(false);
+
+  return (
+    <div className={styles.root}>
+      <button
+        type="button"
+        className={`${styles.trigger} ${open ? styles.triggerActive : ""}`}
+        aria-label="キャプチャ"
+        aria-expanded={open}
+        onClick={() => setOpen((previous) => !previous)}
+      >
+        <CameraIcon size={16} />
+      </button>
+
+      {open && (
+        <div className={styles.panel} role="dialog" aria-label="キャプチャ設定">
+          <p className={styles.heading}>キャプチャ</p>
+
+          <div className={styles.group}>
+            <span className={styles.groupLabel}>ライト</span>
+            <Slider
+              label="環境光"
+              min={0}
+              max={3}
+              step={0.05}
+              value={stage.ambientIntensity}
+              onChange={stage.setAmbientIntensity}
+            />
+            <Slider
+              label="直接光"
+              min={0}
+              max={3}
+              step={0.05}
+              value={stage.directionalIntensity}
+              onChange={stage.setDirectionalIntensity}
+            />
+          </div>
+
+          <div className={styles.group}>
+            <Check label="影をつける" checked={stage.shadowEnabled} onChange={stage.setShadowEnabled} />
+            {stage.shadowEnabled && (
+              <Slider
+                label="影の濃さ"
+                min={0}
+                max={1}
+                step={0.05}
+                value={stage.shadowOpacity}
+                onChange={stage.setShadowOpacity}
+              />
+            )}
+          </div>
+
+          <div className={styles.group}>
+            <Check label="背景を透過する" checked={transparent} onChange={setTransparent} />
+          </div>
+
+          <button type="button" className={styles.capture} onClick={() => stage.capture({ transparent })}>
+            <CameraIcon size={16} />
+            キャプチャして保存
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(v2)/viewer/CapturePanel.tsx
+++ b/app/(v2)/viewer/CapturePanel.tsx
@@ -20,22 +20,28 @@ function Slider({
   value: number;
   onChange: (value: number) => void;
 }) {
+  const trackPct = ((value - min) / (max - min)) * 100;
   return (
-    <label className={styles.slider}>
+    <div className={styles.slider}>
       <span className={styles.sliderHead}>
         <span>{label}</span>
         <span className={styles.value}>{value.toFixed(2)}</span>
       </span>
-      <input
-        type="range"
-        className={styles.range}
-        min={min}
-        max={max}
-        step={step}
-        value={value}
-        onChange={(event) => onChange(Number(event.target.value))}
-      />
-    </label>
+      <div className={styles.bar}>
+        <div className={styles.fill} style={{ width: `${trackPct}%` }} />
+        <span className={styles.knob} style={{ left: `${trackPct}%` }} />
+        <input
+          type="range"
+          className={styles.input}
+          min={min}
+          max={max}
+          step={step}
+          value={value}
+          onChange={(event) => onChange(Number(event.target.value))}
+          aria-label={label}
+        />
+      </div>
+    </div>
   );
 }
 
@@ -78,11 +84,11 @@ export function CapturePanel({ stage }: { stage: StageController }) {
       <button
         type="button"
         className={`${styles.trigger} ${open ? styles.triggerActive : ""}`}
-        aria-label="キャプチャ"
         aria-expanded={open}
         onClick={() => setOpen((previous) => !previous)}
       >
         <CameraIcon size={16} />
+        <span className={styles.triggerLabel}>キャプチャ</span>
       </button>
 
       {open && (

--- a/app/(v2)/viewer/useThreeStage.ts
+++ b/app/(v2)/viewer/useThreeStage.ts
@@ -12,6 +12,9 @@ import { parseGlbTextureSizes, type MaterialTextureSizes } from "../lib/glbTextu
 
 const OUTLINE_COLOR = "#2f6bff"; // v2 highlight (electric blue)
 const CLICK_DRAG_THRESHOLD = 4; // px — distinguishes a pick from an orbit drag
+const DEFAULT_AMBIENT = 0.5;
+const DEFAULT_DIRECTIONAL = 0.5;
+const DEFAULT_SHADOW_OPACITY = 0.3;
 
 export interface StageAnimation {
   name: string;
@@ -172,6 +175,9 @@ interface StageRefs {
   clips: Map<string, THREE.AnimationClip>;
   materials: Map<string, THREE.Material>;
   objectsByUuid: Map<string, THREE.Object3D>;
+  ambientLight: THREE.AmbientLight;
+  directionalLight: THREE.DirectionalLight;
+  ground: THREE.Mesh;
 }
 
 /**
@@ -203,6 +209,10 @@ export function useThreeStage(displayBytes: ArrayBuffer | null, sourceBytes: Arr
   const [pickingEnabled, setPickingEnabled] = useState(true);
   const pickingEnabledRef = useRef(true);
   const [hasSkin, setHasSkin] = useState(false);
+  const [ambientIntensity, setAmbientIntensityState] = useState(DEFAULT_AMBIENT);
+  const [directionalIntensity, setDirectionalIntensityState] = useState(DEFAULT_DIRECTIONAL);
+  const [shadowEnabled, setShadowEnabledState] = useState(false);
+  const [shadowOpacity, setShadowOpacityState] = useState(DEFAULT_SHADOW_OPACITY);
 
   // Keep refs in sync so the render loop can gate the mixer without re-running.
   useEffect(() => {
@@ -254,13 +264,36 @@ export function useThreeStage(displayBytes: ArrayBuffer | null, sourceBytes: Arr
     renderer.toneMappingExposure = 1;
     container.appendChild(renderer.domElement);
 
+    renderer.shadowMap.enabled = false; // toggled on via the capture panel
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+
     const pmrem = new THREE.PMREMGenerator(renderer);
     scene.environment = pmrem.fromScene(new RoomEnvironment()).texture;
 
-    scene.add(new THREE.AmbientLight(0xffffff, 0.5));
-    const directional = new THREE.DirectionalLight(0xffffff, 0.5);
+    const ambientLight = new THREE.AmbientLight(0xffffff, DEFAULT_AMBIENT);
+    scene.add(ambientLight);
+    const directional = new THREE.DirectionalLight(0xffffff, DEFAULT_DIRECTIONAL);
     directional.position.set(5, 5, 5);
+    directional.castShadow = false;
+    directional.shadow.mapSize.set(2048, 2048);
+    directional.shadow.camera.near = 0.1;
+    directional.shadow.camera.far = 50;
+    directional.shadow.camera.left = -10;
+    directional.shadow.camera.right = 10;
+    directional.shadow.camera.top = 10;
+    directional.shadow.camera.bottom = -10;
     scene.add(directional);
+
+    // Shadow catcher: a large ground plane that only renders received shadows.
+    // Hidden until shadows are enabled; repositioned under each loaded model.
+    const ground = new THREE.Mesh(
+      new THREE.PlaneGeometry(100, 100),
+      new THREE.ShadowMaterial({ opacity: DEFAULT_SHADOW_OPACITY })
+    );
+    ground.rotation.x = -Math.PI / 2;
+    ground.receiveShadow = true;
+    ground.visible = false;
+    scene.add(ground);
 
     const controls = new OrbitControls(camera, renderer.domElement);
     controls.enableDamping = true;
@@ -290,6 +323,9 @@ export function useThreeStage(displayBytes: ArrayBuffer | null, sourceBytes: Arr
       clips: new Map(),
       materials: new Map(),
       objectsByUuid: new Map(),
+      ambientLight,
+      directionalLight: directional,
+      ground,
     };
 
     let raf = 0;
@@ -373,9 +409,21 @@ export function useThreeStage(displayBytes: ArrayBuffer | null, sourceBytes: Arr
         stage.scene.add(model);
         stage.model = model;
 
-        // Index objects for tree ↔ viewer selection.
+        // Index objects for tree ↔ viewer selection; let meshes cast/receive
+        // shadows so the shadow toggle (capture panel) works without a reload.
         stage.objectsByUuid = new Map();
-        model.traverse((object) => stage.objectsByUuid.set(object.uuid, object));
+        model.traverse((object) => {
+          stage.objectsByUuid.set(object.uuid, object);
+          const mesh = object as THREE.Mesh;
+          if (mesh.isMesh) {
+            mesh.castShadow = true;
+            mesh.receiveShadow = true;
+          }
+        });
+
+        // Sit the shadow-catching ground at the model's base.
+        const groundBox = new THREE.Box3().setFromObject(model);
+        stage.ground.position.y = groundBox.min.y;
 
         // Extract preview data only from the source (original) model — never
         // from an optimized reflection, so modelStore.meta keeps the "before"
@@ -573,6 +621,90 @@ export function useThreeStage(displayBytes: ArrayBuffer | null, sourceBytes: Arr
     });
   }, []);
 
+  // ── Capture: light / shadow settings + PNG export ────────────────────────
+  const setAmbientIntensity = useCallback((value: number) => {
+    setAmbientIntensityState(value);
+    const stage = refs.current;
+    if (stage) {
+      stage.ambientLight.intensity = value;
+    }
+  }, []);
+
+  const setDirectionalIntensity = useCallback((value: number) => {
+    setDirectionalIntensityState(value);
+    const stage = refs.current;
+    if (stage) {
+      stage.directionalLight.intensity = value;
+    }
+  }, []);
+
+  const setShadowEnabled = useCallback((enabled: boolean) => {
+    setShadowEnabledState(enabled);
+    const stage = refs.current;
+    if (!stage) {
+      return;
+    }
+    stage.renderer.shadowMap.enabled = enabled;
+    stage.directionalLight.castShadow = enabled;
+    stage.ground.visible = enabled;
+    // Materials must recompile when the shadow map is toggled on/off.
+    stage.model?.traverse((object) => {
+      const mesh = object as THREE.Mesh;
+      const materials = Array.isArray(mesh.material) ? mesh.material : mesh.material ? [mesh.material] : [];
+      materials.forEach((material) => (material.needsUpdate = true));
+    });
+  }, []);
+
+  const setShadowOpacity = useCallback((value: number) => {
+    setShadowOpacityState(value);
+    const stage = refs.current;
+    if (stage) {
+      (stage.ground.material as THREE.ShadowMaterial).opacity = value;
+    }
+  }, []);
+
+  const capture = useCallback((options: { transparent: boolean }) => {
+    const stage = refs.current;
+    const container = containerRef.current;
+    if (!stage || !container) {
+      return;
+    }
+    // Render a clean frame without the selection outline.
+    const previousSelection = stage.outlinePass.selectedObjects;
+    stage.outlinePass.selectedObjects = [];
+    stage.composer.render();
+    stage.outlinePass.selectedObjects = previousSelection;
+
+    // Composite the (transparent) WebGL canvas onto a 2D canvas so we can add a
+    // solid background when transparency is off.
+    const source = stage.renderer.domElement;
+    const output = document.createElement("canvas");
+    output.width = source.width;
+    output.height = source.height;
+    const context = output.getContext("2d");
+    if (!context) {
+      return;
+    }
+    if (!options.transparent) {
+      const viewerBg = getComputedStyle(container).getPropertyValue("--color-viewer-bg").trim();
+      context.fillStyle = viewerBg || "#ffffff";
+      context.fillRect(0, 0, output.width, output.height);
+    }
+    context.drawImage(source, 0, 0);
+
+    output.toBlob((blob) => {
+      if (!blob) {
+        return;
+      }
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "capture.png";
+      link.click();
+      URL.revokeObjectURL(url);
+    }, "image/png");
+  }, []);
+
   const resetView = useCallback(() => {
     const stage = refs.current;
     if (!stage || !stage.model) {
@@ -611,6 +743,15 @@ export function useThreeStage(displayBytes: ArrayBuffer | null, sourceBytes: Arr
     hasSkin,
     setWireframe,
     resetView,
+    ambientIntensity,
+    setAmbientIntensity,
+    directionalIntensity,
+    setDirectionalIntensity,
+    shadowEnabled,
+    setShadowEnabled,
+    shadowOpacity,
+    setShadowOpacity,
+    capture,
   };
 }
 


### PR DESCRIPTION
## 概要

legacy にあったキャプチャ機能を v2 に移植。プレビューのビューア右上のカメラボタンからパネルを開き、レンダリングを調整して PNG を書き出す。

## 変更点

- **useThreeStage**: 環境光/直接光を ref 保持、影用のグラウンドプレーン（PCFSoft シャドウ、既定オフ）を追加。ライト強度・影の有効/濃さの setter と `capture({ transparent })` を公開。capture は WebGL キャンバスを 2D キャンバスに合成（`--color-viewer-bg` で塗り、または透過のまま）して `capture.png` をダウンロード。撮影時は選択アウトラインを非表示。
- **CapturePanel**（新規）: ライト（環境光/直接光スライダー）、影をつける（トグル＋濃さ）、背景を透過する、キャプチャして保存 CTA。**プレビューモードのみ**表示。

## UI

- ボタン: ビューア右上（カメラアイコン）。
- 設定: ライトの強さ / 影の有無・濃さ / 背景透過。

## QA (Playwright MCP, port 3100, test2.glb)

- ✅ プレビューでビューア右上にパネル表示（軽量化モードでは非表示）。
- ✅ 環境光/直接光スライダー・影トグルがライブビューに即反映（影がモデル下に描画）。
- ✅ キャプチャで `capture.png`(2190×1714) をダウンロード。既定は不透明の白背景、「背景を透過する」ONで四隅の alpha=0（透過）・モデル部は不透明を実測確認。
- ✅ console エラー 0 / lint・test(48)・build 全パス。