### PR TITLE
v2 UI の英語対応 (i18n)

### DIFF
--- a/app/(v2)/components/AppShell.tsx
+++ b/app/(v2)/components/AppShell.tsx
@@ -17,10 +17,31 @@ export function AppShell({
   fontClassName: string;
 }) {
   const theme = useUiStore((state) => state.theme);
+  const locale = useUiStore((state) => state.locale);
 
   useEffect(() => {
-    void useUiStore.persist.rehydrate();
+    // Detect the browser language on the first visit (no locale stored yet),
+    // then rehydrate any explicitly chosen locale/mode/theme over it.
+    let storedLocale: unknown;
+    try {
+      const raw = localStorage.getItem("gltf-light-v2-ui");
+      storedLocale = raw ? JSON.parse(raw)?.state?.locale : undefined;
+    } catch {
+      storedLocale = undefined;
+    }
+    void useUiStore.persist.rehydrate()?.then(() => {
+      if (!storedLocale) {
+        useUiStore
+          .getState()
+          .setLocale(navigator.language.toLowerCase().startsWith("ja") ? "ja" : "en");
+      }
+    });
   }, []);
+
+  // Keep <html lang> in sync with the chosen locale (legacy stays "en").
+  useEffect(() => {
+    document.documentElement.lang = locale;
+  }, [locale]);
 
   return (
     <div data-app="v2" data-theme={theme} className={fontClassName}>

--- a/app/(v2)/components/FileDropzone.tsx
+++ b/app/(v2)/components/FileDropzone.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState } from "react";
 import { useModelUpload } from "../hooks/useModelUpload";
+import { useTranslations } from "../i18n/useTranslations";
 import { UploadIcon } from "../icons";
 import styles from "./FileDropzone.module.scss";
 
@@ -13,6 +14,7 @@ interface FileDropzoneProps {
 /** Upload dropzone: click or drag & drop a `.glb` into modelStore. */
 export function FileDropzone({ variant = "panel" }: FileDropzoneProps) {
   const { acceptFiles, error } = useModelUpload();
+  const t = useTranslations();
   const inputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
 
@@ -49,9 +51,9 @@ export function FileDropzone({ variant = "panel" }: FileDropzoneProps) {
           <UploadIcon size={24} />
         </span>
         <span className={styles.text}>
-          <span className={styles.title}>3Dモデルをアップロード</span>
-          <span className={styles.hint}>ドラッグ&amp;ドロップ、またはクリック（.glb）</span>
-          <span className={styles.note}>※サーバーにアップロードすることはありません</span>
+          <span className={styles.title}>{t("dropzone.title")}</span>
+          <span className={styles.hint}>{t("dropzone.hint")}</span>
+          <span className={styles.note}>{t("common.noUpload")}</span>
         </span>
       </button>
       {error && (

--- a/app/(v2)/components/Header.module.scss
+++ b/app/(v2)/components/Header.module.scss
@@ -116,3 +116,27 @@
     background: var(--color-track);
   }
 }
+
+.langToggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 30px;
+  padding: 0 var(--space-10);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--color-text-muted);
+  font-family: inherit;
+  font-weight: 600;
+  font-size: var(--font-size-11);
+  line-height: 14px;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color 0.15s ease, background-color 0.15s ease;
+
+  &:hover {
+    color: var(--color-text);
+    background: var(--color-track);
+  }
+}

--- a/app/(v2)/components/Header.tsx
+++ b/app/(v2)/components/Header.tsx
@@ -2,6 +2,8 @@
 
 import { useModelStore } from "../store/modelStore";
 import { useUiStore, type Mode } from "../store/uiStore";
+import { useTranslations } from "../i18n/useTranslations";
+import type { MessageKey } from "../i18n/ja";
 import { analytics } from "../lib/analytics";
 import {
   RocketIcon,
@@ -13,9 +15,13 @@ import {
 } from "../icons";
 import styles from "./Header.module.scss";
 
-const MODE_TABS: { value: Mode; label: string; Icon: (props: IconProps) => React.ReactElement }[] = [
-  { value: "preview", label: "プレビュー", Icon: EyeIcon },
-  { value: "optimize", label: "軽量化", Icon: ZapIcon },
+const MODE_TABS: {
+  value: Mode;
+  labelKey: MessageKey;
+  Icon: (props: IconProps) => React.ReactElement;
+}[] = [
+  { value: "preview", labelKey: "header.preview", Icon: EyeIcon },
+  { value: "optimize", labelKey: "header.optimize", Icon: ZapIcon },
 ];
 
 export function Header() {
@@ -24,6 +30,9 @@ export function Header() {
   const setMode = useUiStore((state) => state.setMode);
   const theme = useUiStore((state) => state.theme);
   const toggleTheme = useUiStore((state) => state.toggleTheme);
+  const locale = useUiStore((state) => state.locale);
+  const toggleLocale = useUiStore((state) => state.toggleLocale);
+  const t = useTranslations();
 
   return (
     <header className={styles.header}>
@@ -33,15 +42,15 @@ export function Header() {
         </span>
         <span className={styles.brandText}>
           <span className={styles.brandTitle}>gltf-light</span>
-          <span className={styles.brandSubtitle}>オフラインでglbのプレビューと軽量化を</span>
+          <span className={styles.brandSubtitle}>{t("header.brandSubtitle")}</span>
         </span>
       </div>
 
       {/* Mode tabs only make sense once a model is loaded. */}
       <div className={styles.center}>
         {hasModel && (
-          <div className={styles.modeTabs} role="tablist" aria-label="表示モード">
-            {MODE_TABS.map(({ value, label, Icon }) => {
+          <div className={styles.modeTabs} role="tablist" aria-label={t("header.modeTabs")}>
+            {MODE_TABS.map(({ value, labelKey, Icon }) => {
               const isActive = mode === value;
               return (
                 <button
@@ -58,7 +67,7 @@ export function Header() {
                   }}
                 >
                   <Icon size={14} />
-                  {label}
+                  {t(labelKey)}
                 </button>
               );
             })}
@@ -69,9 +78,17 @@ export function Header() {
       <div className={styles.right}>
         <button
           type="button"
+          className={styles.langToggle}
+          onClick={toggleLocale}
+          aria-label={t("header.language")}
+        >
+          {locale === "ja" ? "EN" : "日本語"}
+        </button>
+        <button
+          type="button"
           className={styles.themeToggle}
           onClick={toggleTheme}
-          aria-label={theme === "light" ? "ダークモードに切り替え" : "ライトモードに切り替え"}
+          aria-label={theme === "light" ? t("header.toDark") : t("header.toLight")}
         >
           {theme === "light" ? <MoonIcon size={16} /> : <SunIcon size={16} />}
         </button>

--- a/app/(v2)/components/LegacyLink.tsx
+++ b/app/(v2)/components/LegacyLink.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Link from "next/link";
+import { useTranslations } from "../i18n/useTranslations";
 import styles from "./LegacyLink.module.scss";
 
 /**
@@ -6,9 +9,10 @@ import styles from "./LegacyLink.module.scss";
  * sidebar, below the cards, so it never competes with the main flow.
  */
 export function LegacyLink() {
+  const t = useTranslations();
   return (
     <Link className={styles.link} href="/legacy">
-      以前のバージョンを開く
+      {t("legacy.open")}
     </Link>
   );
 }

--- a/app/(v2)/components/ModelSummaryCard.tsx
+++ b/app/(v2)/components/ModelSummaryCard.tsx
@@ -4,6 +4,7 @@ import { useModelStore } from "../store/modelStore";
 import { useUiStore } from "../store/uiStore";
 import { formatFileSize } from "../lib/formatFileSize";
 import { analytics } from "../lib/analytics";
+import { useTranslations } from "../i18n/useTranslations";
 import { FileIcon, ZapIcon, ArrowRightIcon } from "../icons";
 import styles from "./ModelSummaryCard.module.scss";
 
@@ -17,6 +18,7 @@ const POLYGON_PLACEHOLDER = "—"; // filled once the glb is parsed (issue 0-6 /
 export function ModelSummaryCard() {
   const meta = useModelStore((state) => state.meta);
   const setMode = useUiStore((state) => state.setMode);
+  const t = useTranslations();
 
   if (!meta) {
     return null;
@@ -35,11 +37,11 @@ export function ModelSummaryCard() {
 
       <div className={styles.dataArea}>
         <div className={styles.data}>
-          <span className={styles.dataLabel}>サイズ</span>
+          <span className={styles.dataLabel}>{t("model.size")}</span>
           <span className={styles.dataValue}>{formatFileSize(meta.size)}</span>
         </div>
         <div className={styles.data}>
-          <span className={styles.dataLabel}>ポリゴン数</span>
+          <span className={styles.dataLabel}>{t("common.polygons")}</span>
           <span className={styles.dataValue}>
             {meta.polygons != null ? meta.polygons.toLocaleString() : POLYGON_PLACEHOLDER}
           </span>
@@ -55,7 +57,7 @@ export function ModelSummaryCard() {
         }}
       >
         <ZapIcon size={16} />
-        <span className={styles.ctaLabel}>モデルの軽量化をする</span>
+        <span className={styles.ctaLabel}>{t("model.optimizeCta")}</span>
         <ArrowRightIcon size={16} />
       </button>
     </div>

--- a/app/(v2)/components/ServiceInfo.tsx
+++ b/app/(v2)/components/ServiceInfo.tsx
@@ -1,48 +1,53 @@
+"use client";
+
 import { EyeIcon, FileIcon, ZapIcon, type IconProps } from "../icons";
+import { useTranslations } from "../i18n/useTranslations";
+import type { MessageKey } from "../i18n/ja";
 import styles from "./ServiceInfo.module.scss";
 
 type InfoCard = {
   Icon: (props: IconProps) => React.ReactElement;
-  title: string;
-  body: string;
-  note?: string;
+  titleKey: MessageKey;
+  bodyKey: MessageKey;
+  noteKey?: MessageKey;
 };
 
 const CARDS: InfoCard[] = [
   {
     Icon: EyeIcon,
-    title: "3Dモデルのプレビュー",
-    body: "専用アプリがなくても3Dモデルをアップロードするだけで表示確認ができます。",
-    note: "※サーバーにアップロードすることはありません",
+    titleKey: "service.preview.title",
+    bodyKey: "service.preview.body",
+    noteKey: "common.noUpload",
   },
   {
     Icon: FileIcon,
-    title: "アニメーションや詳細情報の確認",
-    body: "3Dモデルに含まれるアニメーションの再生や、マテリアルや使用テクスチャ、メッシュ構造の確認も可能です。",
+    titleKey: "service.info.title",
+    bodyKey: "service.info.body",
   },
   {
     Icon: ZapIcon,
-    title: "最適化の提案とワンクリックでの反映",
-    body: "3Dモデルをウェブで扱う上での最適化をご提案、ワンクリックで反映いただけます。ご自身での調整も可能です。",
+    titleKey: "service.optimize.title",
+    bodyKey: "service.optimize.body",
   },
 ];
 
 /** Sidebar content for the empty (no model loaded) state. */
 export function ServiceInfo() {
+  const t = useTranslations();
   return (
     <>
-      <h2 className={styles.heading}>このサービスでできること</h2>
-      {CARDS.map(({ Icon, title, body, note }) => (
-        <article key={title} className={styles.card}>
+      <h2 className={styles.heading}>{t("service.heading")}</h2>
+      {CARDS.map(({ Icon, titleKey, bodyKey, noteKey }) => (
+        <article key={titleKey} className={styles.card}>
           <div className={styles.sectionTitle}>
             <span className={styles.sectionIcon}>
               <Icon size={14} />
             </span>
-            <span className={styles.sectionLabel}>{title}</span>
+            <span className={styles.sectionLabel}>{t(titleKey)}</span>
           </div>
           <div className={styles.text}>
-            <p className={styles.body}>{body}</p>
-            {note && <p className={styles.note}>{note}</p>}
+            <p className={styles.body}>{t(bodyKey)}</p>
+            {noteKey && <p className={styles.note}>{t(noteKey)}</p>}
           </div>
         </article>
       ))}

--- a/app/(v2)/features/optimize/BeforeAfterSummary.tsx
+++ b/app/(v2)/features/optimize/BeforeAfterSummary.tsx
@@ -4,6 +4,7 @@ import { useModelStore } from "../../store/modelStore";
 import { useOptimizeStore } from "../../store/optimizeStore";
 import { formatFileSize } from "../../lib/formatFileSize";
 import { analytics } from "../../lib/analytics";
+import { useTranslations } from "../../i18n/useTranslations";
 import { DownloadIcon } from "../../icons";
 
 const bytesToMb = (bytes: number) => +(bytes / 1024 / 1024).toFixed(2);
@@ -27,6 +28,7 @@ export function BeforeAfterSummary() {
   const estimate = useOptimizeStore((state) => state.estimate);
   const resultBytes = useOptimizeStore((state) => state.result?.bytes);
   const settings = useOptimizeStore((state) => state.settings);
+  const t = useTranslations();
 
   const ready = status === "ready" && estimate != null;
 
@@ -70,7 +72,7 @@ export function BeforeAfterSummary() {
         ) : (
           <span className={styles.placeholder}>
             <span className={styles.spinner} aria-hidden="true" />
-            計算中…
+            {t("summary.calculating")}
           </span>
         )}
       </div>
@@ -78,7 +80,7 @@ export function BeforeAfterSummary() {
       <div className={styles.actions}>
         <button type="button" className={styles.save} onClick={handleSave} disabled={!ready || !resultBytes}>
           <DownloadIcon size={16} />
-          軽量化して保存
+          {t("summary.save")}
         </button>
       </div>
     </div>

--- a/app/(v2)/features/optimize/OptimizeSidebar.tsx
+++ b/app/(v2)/features/optimize/OptimizeSidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { StageController } from "../../viewer/useThreeStage";
+import { useTranslations } from "../../i18n/useTranslations";
 import { useOptimizePipeline } from "./useOptimizePipeline";
 import { PruneDedupCard } from "./PruneDedupCard";
 import { TextureOptimizeCard } from "./TextureOptimizeCard";
@@ -15,10 +16,11 @@ import styles from "./OptimizeSidebar.module.scss";
  */
 export function OptimizeSidebar({ stage }: { stage: StageController }) {
   useOptimizePipeline();
+  const t = useTranslations();
 
   return (
     <div className={styles.sidebar}>
-      <h2 className={styles.heading}>軽量化の設定はカスタマイズが可能です</h2>
+      <h2 className={styles.heading}>{t("optimize.heading")}</h2>
       <PruneDedupCard />
       <TextureOptimizeCard stage={stage} />
       <PolygonReduceCard stage={stage} />

--- a/app/(v2)/features/optimize/PolygonReduceCard.tsx
+++ b/app/(v2)/features/optimize/PolygonReduceCard.tsx
@@ -5,6 +5,7 @@ import type { StageController } from "../../viewer/useThreeStage";
 import { useModelStore } from "../../store/modelStore";
 import { useOptimizeStore } from "../../store/optimizeStore";
 import { Switch } from "../../components/ui/Switch";
+import { useTranslations } from "../../i18n/useTranslations";
 import { LayersIcon, CheckIcon } from "../../icons";
 import card from "./OptimizeCard.module.scss";
 import styles from "./PolygonReduceCard.module.scss";
@@ -18,6 +19,7 @@ export function PolygonReduceCard({ stage }: { stage: StageController }) {
   const setSettings = useOptimizeStore((state) => state.setSettings);
   const resultPolygons = useOptimizeStore((state) => state.result?.stats?.polygons);
   const [wireframe, setWireframe] = useState(false);
+  const t = useTranslations();
 
   const enabled = reduce.enabled;
   const reductionPct = Math.round((1 - reduce.ratio) * 100);
@@ -47,17 +49,17 @@ export function PolygonReduceCard({ stage }: { stage: StageController }) {
         <span className={card.icon}>
           <LayersIcon size={14} />
         </span>
-        <span className={card.label}>ポリゴンの削減</span>
-        <Switch checked={enabled} onChange={toggleEnabled} label="ポリゴンの削減" />
+        <span className={card.label}>{t("polygon.label")}</span>
+        <Switch checked={enabled} onChange={toggleEnabled} label={t("polygon.label")} />
       </div>
-      <p className={card.text}>面の数を減らして軽くします（既定はオフ）。</p>
-      <p className={styles.warning}>※形やアニメーションが崩れる場合があります</p>
+      <p className={card.text}>{t("polygon.text")}</p>
+      <p className={styles.warning}>{t("polygon.warning")}</p>
 
       {enabled && (
         <>
           <div className={styles.slider}>
             <span className={styles.sliderHead}>
-              <span>削減率</span>
+              <span>{t("polygon.reductionRate")}</span>
               <span className={styles.value}>{reductionPct}%</span>
             </span>
             <div className={styles.bar}>
@@ -71,7 +73,7 @@ export function PolygonReduceCard({ stage }: { stage: StageController }) {
                 step={5}
                 value={reductionPct}
                 onChange={(event) => setReduction(Number(event.target.value))}
-                aria-label="削減率"
+                aria-label={t("polygon.reductionRate")}
               />
             </div>
           </div>
@@ -85,12 +87,12 @@ export function PolygonReduceCard({ stage }: { stage: StageController }) {
             <span className={`${styles.check} ${wireframe ? styles.checkOn : ""}`} aria-hidden="true">
               {wireframe && <CheckIcon size={9} />}
             </span>
-            <span className={styles.wireframeLabel}>ワイヤーフレームで確認</span>
+            <span className={styles.wireframeLabel}>{t("polygon.wireframe")}</span>
           </button>
 
           <div className={card.dataArea}>
             <div className={card.data}>
-              <span className={card.dataLabel}>ポリゴン数</span>
+              <span className={card.dataLabel}>{t("common.polygons")}</span>
               <span className={card.dataValue}>
                 {(resultPolygons ?? originalPolygons ?? 0).toLocaleString()}
               </span>

--- a/app/(v2)/features/optimize/PruneDedupCard.tsx
+++ b/app/(v2)/features/optimize/PruneDedupCard.tsx
@@ -2,6 +2,7 @@
 
 import { useOptimizeStore } from "../../store/optimizeStore";
 import { Switch } from "../../components/ui/Switch";
+import { useTranslations } from "../../i18n/useTranslations";
 import { TrashIcon } from "../../icons";
 import styles from "./OptimizeCard.module.scss";
 
@@ -11,6 +12,7 @@ export function PruneDedupCard() {
   const setSettings = useOptimizeStore((state) => state.setSettings);
   const status = useOptimizeStore((state) => state.status);
   const unusedRemoved = useOptimizeStore((state) => state.result?.stats?.unusedRemoved);
+  const t = useTranslations();
 
   return (
     <div className={styles.card}>
@@ -18,17 +20,17 @@ export function PruneDedupCard() {
         <span className={styles.icon}>
           <TrashIcon size={14} />
         </span>
-        <span className={styles.label}>未使用データの削除</span>
+        <span className={styles.label}>{t("prune.label")}</span>
         <Switch
           checked={enabled}
           onChange={(checked) => setSettings({ pruneDedup: checked })}
-          label="未使用データの削除"
+          label={t("prune.label")}
         />
       </div>
-      <p className={styles.text}>使われていないデータを削除して軽量化します。</p>
+      <p className={styles.text}>{t("prune.text")}</p>
       <div className={styles.dataArea}>
         <div className={styles.data}>
-          <span className={styles.dataLabel}>未使用データ</span>
+          <span className={styles.dataLabel}>{t("prune.dataLabel")}</span>
           <span className={styles.dataValue}>
             {status === "estimating" ? "…" : (unusedRemoved ?? 0).toLocaleString()}
           </span>

--- a/app/(v2)/features/optimize/TextureOptimizeCard.tsx
+++ b/app/(v2)/features/optimize/TextureOptimizeCard.tsx
@@ -6,6 +6,8 @@ import { useOptimizeStore } from "../../store/optimizeStore";
 import { useThreeStage } from "../../viewer/useThreeStage";
 import { Switch } from "../../components/ui/Switch";
 import { formatFileSize } from "../../lib/formatFileSize";
+import { useTranslations } from "../../i18n/useTranslations";
+import type { MessageKey } from "../../i18n/ja";
 import { ImageIcon, CheckIcon, TrashIcon, RotateIcon } from "../../icons";
 import card from "./OptimizeCard.module.scss";
 import styles from "./TextureOptimizeCard.module.scss";
@@ -14,10 +16,10 @@ type StageController = ReturnType<typeof useThreeStage>;
 
 type Resolution = 512 | 1024 | 2048;
 
-const OPTIONS: { value: Resolution; sub: string }[] = [
-  { value: 512, sub: "最軽量" },
-  { value: 1024, sub: "おすすめ" },
-  { value: 2048, sub: "高品質" },
+const OPTIONS: { value: Resolution; subKey: MessageKey }[] = [
+  { value: 512, subKey: "texture.chip.min" },
+  { value: 1024, subKey: "texture.chip.recommended" },
+  { value: 2048, subKey: "texture.chip.high" },
 ];
 
 /** Resolution offered per-texture (only downscales below the current edge). */
@@ -61,6 +63,7 @@ function TextureRowItem({ texture }: { texture: TextureRow }) {
   const setTextureOverride = useOptimizeStore((state) => state.setTextureOverride);
   const deleted = useOptimizeStore((state) => state.settings.deletedTextures.includes(texture.name));
   const toggleTextureDeleted = useOptimizeStore((state) => state.toggleTextureDeleted);
+  const t = useTranslations();
 
   const longest = Math.max(texture.width, texture.height);
   const choices = RESOLUTIONS.filter((resolution) => resolution < longest);
@@ -83,7 +86,11 @@ function TextureRowItem({ texture }: { texture: TextureRow }) {
         <button
           type="button"
           className={`${styles.action} ${deleted ? styles.restore : styles.danger}`}
-          aria-label={deleted ? `${texture.name} を戻す` : `${texture.name} を削除`}
+          aria-label={
+            deleted
+              ? t("texture.restore", { name: texture.name })
+              : t("texture.delete", { name: texture.name })
+          }
           aria-pressed={deleted}
           onClick={() => toggleTextureDeleted(texture.name)}
         >
@@ -92,7 +99,7 @@ function TextureRowItem({ texture }: { texture: TextureRow }) {
         <div className={styles.selectWrap}>
           <select
             className={styles.select}
-            aria-label={`${texture.name} の解像度`}
+            aria-label={t("texture.resolutionOf", { name: texture.name })}
             value={override ?? "keep"}
             onChange={(event) =>
               setTextureOverride(
@@ -102,10 +109,12 @@ function TextureRowItem({ texture }: { texture: TextureRow }) {
             }
             disabled={deleted || choices.length === 0}
           >
-            <option value="keep">変更なし</option>
+            <option value="keep">{t("texture.keep")}</option>
             {choices.map((resolution) => (
               <option key={resolution} value={resolution}>
-                {resolution === RECOMMENDED ? `${resolution}（おすすめ）` : resolution}
+                {resolution === RECOMMENDED
+                  ? t("texture.recommendedOption", { resolution })
+                  : resolution}
               </option>
             ))}
           </select>
@@ -121,6 +130,7 @@ export function TextureOptimizeCard({ stage }: { stage: StageController }) {
   const textureMaxSize = useOptimizeStore((state) => state.settings.textureMaxSize);
   const perTexture = useOptimizeStore((state) => state.settings.perTexture);
   const setSettings = useOptimizeStore((state) => state.setSettings);
+  const t = useTranslations();
 
   const textures = useMemo(() => collectTextures(stage), [stage.materials]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -158,18 +168,18 @@ export function TextureOptimizeCard({ stage }: { stage: StageController }) {
         <span className={card.icon}>
           <ImageIcon size={14} />
         </span>
-        <span className={card.label}>テクスチャの最適化</span>
-        <Switch checked={enabled} onChange={toggle} label="テクスチャの最適化" />
+        <span className={card.label}>{t("texture.label")}</span>
+        <Switch checked={enabled} onChange={toggle} label={t("texture.label")} />
       </div>
-      <p className={card.text}>最大解像度を選ぶだけで、すべての画像をまとめて縮小します。</p>
-      <p className={styles.note}>※指定解像度を超えるもののみ調整します</p>
+      <p className={card.text}>{t("texture.text")}</p>
+      <p className={styles.note}>{t("texture.note")}</p>
 
       {enabled && (
         <>
           {maxTextureSize != null && (
             <div className={card.dataArea}>
               <div className={card.data}>
-                <span className={card.dataLabel}>現在の最大解像度</span>
+                <span className={card.dataLabel}>{t("texture.currentMax")}</span>
                 <span className={card.dataValue}>{maxTextureSize.toLocaleString()}</span>
               </div>
             </div>
@@ -186,7 +196,7 @@ export function TextureOptimizeCard({ stage }: { stage: StageController }) {
               <span className={`${styles.check} ${perTexture ? styles.checkOn : ""}`}>
                 {perTexture && <CheckIcon size={10} />}
               </span>
-              <span className={styles.individualLabel}>個別で設定する</span>
+              <span className={styles.individualLabel}>{t("texture.individual")}</span>
             </button>
           )}
 
@@ -197,8 +207,8 @@ export function TextureOptimizeCard({ stage }: { stage: StageController }) {
               ))}
             </div>
           ) : (
-            <div className={styles.chips} role="group" aria-label="最大解像度">
-              {OPTIONS.map(({ value, sub }) => (
+            <div className={styles.chips} role="group" aria-label={t("texture.maxResolution")}>
+              {OPTIONS.map(({ value, subKey }) => (
                 <button
                   key={value}
                   type="button"
@@ -207,7 +217,7 @@ export function TextureOptimizeCard({ stage }: { stage: StageController }) {
                   onClick={() => selectResolution(value)}
                 >
                   <span className={styles.chipValue}>{value}</span>
-                  <span className={styles.chipSub}>{sub}</span>
+                  <span className={styles.chipSub}>{t(subKey)}</span>
                 </button>
               ))}
             </div>

--- a/app/(v2)/features/preview/AnimationTab.tsx
+++ b/app/(v2)/features/preview/AnimationTab.tsx
@@ -2,6 +2,7 @@
 
 import type { StageController } from "../../viewer/useThreeStage";
 import { FilmIcon, PlayIcon, PauseIcon, CheckIcon } from "../../icons";
+import { useTranslations } from "../../i18n/useTranslations";
 import { TabCard } from "./TabCard";
 import styles from "./AnimationTab.module.scss";
 
@@ -13,12 +14,13 @@ function formatClip(duration: number): string {
 
 /** 動き: animation clip list (toggle which play) + player (play/pause + seek). */
 export function AnimationTab({ stage }: { stage: StageController }) {
+  const t = useTranslations();
   const { animations, activeClips, isPlaying, currentTime, duration, togglePlay, toggleClip, seek } = stage;
   const clampedTime = duration > 0 ? Math.min(currentTime % duration || 0, duration) : 0;
   const progress = duration > 0 ? (clampedTime / duration) * 100 : 0;
 
   return (
-    <TabCard Icon={FilmIcon} title="アニメーション">
+    <TabCard Icon={FilmIcon} title={t("tabs.animation")}>
       <ul className={styles.list}>
         {animations.map((clip) => {
           const checked = activeClips.includes(clip.name);
@@ -46,7 +48,7 @@ export function AnimationTab({ stage }: { stage: StageController }) {
           type="button"
           className={styles.playButton}
           onClick={togglePlay}
-          aria-label={isPlaying ? "停止" : "再生"}
+          aria-label={isPlaying ? t("animation.pause") : t("animation.play")}
         >
           {isPlaying ? <PauseIcon size={13} /> : <PlayIcon size={13} />}
         </button>
@@ -64,7 +66,7 @@ export function AnimationTab({ stage }: { stage: StageController }) {
               step={0.01}
               value={clampedTime}
               onChange={(event) => seek(Number(event.target.value))}
-              aria-label="再生位置"
+              aria-label={t("animation.seek")}
             />
           </div>
           <span className={styles.timeLabel}>

--- a/app/(v2)/features/preview/ContextTabs.tsx
+++ b/app/(v2)/features/preview/ContextTabs.tsx
@@ -3,6 +3,8 @@
 import { useMemo, useState } from "react";
 import type { StageController } from "../../viewer/useThreeStage";
 import { FilmIcon, SphereIcon, LayersIcon, type IconProps } from "../../icons";
+import { useTranslations } from "../../i18n/useTranslations";
+import type { MessageKey } from "../../i18n/ja";
 import { AnimationTab } from "./AnimationTab";
 import { MaterialTab } from "./MaterialTab";
 import { MeshTab } from "./MeshTab";
@@ -10,15 +12,16 @@ import styles from "./ContextTabs.module.scss";
 
 type TabKey = "animation" | "material" | "mesh";
 
-const TABS: { key: TabKey; label: string; Icon: (props: IconProps) => React.ReactElement }[] = [
-  { key: "animation", label: "アニメーション", Icon: FilmIcon },
-  { key: "material", label: "マテリアル", Icon: SphereIcon },
-  { key: "mesh", label: "メッシュ", Icon: LayersIcon },
+const TABS: { key: TabKey; labelKey: MessageKey; Icon: (props: IconProps) => React.ReactElement }[] = [
+  { key: "animation", labelKey: "tabs.animation", Icon: FilmIcon },
+  { key: "material", labelKey: "tabs.material", Icon: SphereIcon },
+  { key: "mesh", labelKey: "tabs.mesh", Icon: LayersIcon },
 ];
 
 /** Contextual preview tabs (Figma preview screen): animation / material / mesh.
  *  Empty tabs are disabled (F-13). */
 export function ContextTabs({ stage }: { stage: StageController }) {
+  const t = useTranslations();
   const counts: Record<TabKey, number> = {
     animation: stage.animations.length,
     material: stage.materials.length,
@@ -35,8 +38,8 @@ export function ContextTabs({ stage }: { stage: StageController }) {
 
   return (
     <div className={styles.container}>
-      <div className={styles.tabs} role="tablist" aria-label="プレビュー情報">
-        {TABS.map(({ key, label, Icon }) => {
+      <div className={styles.tabs} role="tablist" aria-label={t("tabs.label")}>
+        {TABS.map(({ key, labelKey, Icon }) => {
           const disabled = counts[key] === 0;
           const isActive = activeKey === key;
           return (
@@ -50,7 +53,7 @@ export function ContextTabs({ stage }: { stage: StageController }) {
               onClick={() => setActive(key)}
             >
               <Icon size={16} />
-              {label}
+              {t(labelKey)}
             </button>
           );
         })}

--- a/app/(v2)/features/preview/MaterialTab.tsx
+++ b/app/(v2)/features/preview/MaterialTab.tsx
@@ -5,6 +5,7 @@ import type { StageController } from "../../viewer/useThreeStage";
 import { useUiStore } from "../../store/uiStore";
 import { formatFileSize } from "../../lib/formatFileSize";
 import { analytics } from "../../lib/analytics";
+import { useTranslations } from "../../i18n/useTranslations";
 import { SphereIcon, ZapIcon, ArrowRightIcon } from "../../icons";
 import { TabCard } from "./TabCard";
 import styles from "./MaterialTab.module.scss";
@@ -31,6 +32,7 @@ function ValueBar({ label, value }: { label: string; value: number }) {
 export function MaterialTab({ stage }: { stage: StageController }) {
   const [openIds, setOpenIds] = useState<Set<string>>(new Set());
   const setMode = useUiStore((state) => state.setMode);
+  const t = useTranslations();
 
   const toggle = (id: string) =>
     setOpenIds((prev) => {
@@ -44,7 +46,7 @@ export function MaterialTab({ stage }: { stage: StageController }) {
     });
 
   return (
-    <TabCard Icon={SphereIcon} title="マテリアル">
+    <TabCard Icon={SphereIcon} title={t("tabs.material")}>
       <ul className={styles.list}>
         {stage.materials.map((material) => {
           const open = openIds.has(material.id);
@@ -65,7 +67,7 @@ export function MaterialTab({ stage }: { stage: StageController }) {
                 <div className={styles.details}>
                   {material.textures.length > 0 && (
                     <div className={styles.textureBlock}>
-                      <span className={styles.textureHeading}>テクスチャ</span>
+                      <span className={styles.textureHeading}>{t("material.textures")}</span>
                       {material.textures.map((texture, index) => (
                         <div key={`${texture.type}-${index}`} className={styles.texture}>
                           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -86,8 +88,8 @@ export function MaterialTab({ stage }: { stage: StageController }) {
                       ))}
                     </div>
                   )}
-                  <ValueBar label="粗さ (Roughness)" value={material.roughness} />
-                  <ValueBar label="金属感 (Metalness)" value={material.metalness} />
+                  <ValueBar label={t("material.roughness")} value={material.roughness} />
+                  <ValueBar label={t("material.metalness")} value={material.metalness} />
                 </div>
               )}
             </li>
@@ -104,7 +106,7 @@ export function MaterialTab({ stage }: { stage: StageController }) {
         }}
       >
         <ZapIcon size={16} />
-        <span className={styles.ctaLabel}>マテリアルの最適化をする</span>
+        <span className={styles.ctaLabel}>{t("material.optimizeCta")}</span>
         <ArrowRightIcon size={16} />
       </button>
     </TabCard>

--- a/app/(v2)/features/preview/MeshTab.tsx
+++ b/app/(v2)/features/preview/MeshTab.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import type { StageController, MeshNode } from "../../viewer/useThreeStage";
 import { useUiStore } from "../../store/uiStore";
+import { useTranslations } from "../../i18n/useTranslations";
 import { LayersIcon, CubeIcon, CheckIcon, ZapIcon, ArrowRightIcon } from "../../icons";
 import { TabCard } from "./TabCard";
 import styles from "./MeshTab.module.scss";
@@ -25,6 +26,7 @@ function flatten(node: MeshNode, collapsed: Set<string>, depth = 0, acc: FlatRow
 export function MeshTab({ stage }: { stage: StageController }) {
   const { meshTree, selectedUuid, selectMesh, pickingEnabled, setPickingEnabled } = stage;
   const setMode = useUiStore((state) => state.setMode);
+  const t = useTranslations();
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
 
   const rows = meshTree ? flatten(meshTree, collapsed) : [];
@@ -41,7 +43,7 @@ export function MeshTab({ stage }: { stage: StageController }) {
     });
 
   return (
-    <TabCard Icon={LayersIcon} title="メッシュ構造">
+    <TabCard Icon={LayersIcon} title={t("mesh.title")}>
       <button
         type="button"
         className={styles.pickToggle}
@@ -51,7 +53,7 @@ export function MeshTab({ stage }: { stage: StageController }) {
         <span className={`${styles.check} ${pickingEnabled ? styles.checkOn : ""}`} aria-hidden="true">
           {pickingEnabled && <CheckIcon size={9} />}
         </span>
-        <span className={styles.pickLabel}>右のビューアーでクリックしてメッシュを選択する</span>
+        <span className={styles.pickLabel}>{t("mesh.pickHint")}</span>
       </button>
 
       <div className={styles.treeWrap}>
@@ -75,7 +77,7 @@ export function MeshTab({ stage }: { stage: StageController }) {
                     type="button"
                     className={styles.toggle}
                     onClick={() => toggleCollapse(node.uuid)}
-                    aria-label={open ? "折りたたむ" : "展開する"}
+                    aria-label={open ? t("mesh.collapse") : t("mesh.expand")}
                   >
                     {open ? "▾" : "▸"}
                   </button>
@@ -98,7 +100,7 @@ export function MeshTab({ stage }: { stage: StageController }) {
 
       <button type="button" className={styles.cta} onClick={() => setMode("optimize")}>
         <ZapIcon size={16} />
-        <span className={styles.ctaLabel}>ポリゴンの最適化をする</span>
+        <span className={styles.ctaLabel}>{t("mesh.optimizeCta")}</span>
         <ArrowRightIcon size={16} />
       </button>
     </TabCard>

--- a/app/(v2)/features/preview/ModelWorkspace.tsx
+++ b/app/(v2)/features/preview/ModelWorkspace.tsx
@@ -4,6 +4,7 @@ import { useModelStore } from "../../store/modelStore";
 import { useUiStore } from "../../store/uiStore";
 import { useOptimizeStore } from "../../store/optimizeStore";
 import { useViewerDrop } from "../../hooks/useViewerDrop";
+import { useTranslations } from "../../i18n/useTranslations";
 import { useThreeStage } from "../../viewer/useThreeStage";
 import { Stage } from "../../viewer/Stage";
 import { CapturePanel } from "../../viewer/CapturePanel";
@@ -27,6 +28,7 @@ export function ModelWorkspace() {
   const displayBytes = mode === "optimize" && resultBytes ? resultBytes : bytes;
   const stage = useThreeStage(displayBytes, bytes);
   const { isDragging, dropProps } = useViewerDrop();
+  const t = useTranslations();
 
   return (
     <>
@@ -43,7 +45,7 @@ export function ModelWorkspace() {
           </>
         )}
       </aside>
-      <section className={styles.viewer} aria-label="3Dビュー" {...dropProps}>
+      <section className={styles.viewer} aria-label={t("viewer.label")} {...dropProps}>
         <Stage
           containerRef={stage.containerRef}
           onPointerDown={stage.onPointerDown}
@@ -55,7 +57,7 @@ export function ModelWorkspace() {
         />
         <Copyright />
         {mode === "preview" && <CapturePanel stage={stage} />}
-        {isDragging && <div className={styles.dropOverlay}>ここに .glb をドロップして差し替え</div>}
+        {isDragging && <div className={styles.dropOverlay}>{t("viewer.dropReplace")}</div>}
       </section>
     </>
   );

--- a/app/(v2)/hooks/useModelUpload.ts
+++ b/app/(v2)/hooks/useModelUpload.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import { useModelStore } from "../store/modelStore";
 import { useUiStore } from "../store/uiStore";
+import { useTranslations } from "../i18n/useTranslations";
 import { analytics } from "../lib/analytics";
 
 const GLB_EXTENSION = ".glb";
@@ -13,6 +14,7 @@ const GLB_EXTENSION = ".glb";
 export function useModelUpload() {
   const loadModel = useModelStore((state) => state.loadModel);
   const setMode = useUiStore((state) => state.setMode);
+  const t = useTranslations();
   const [error, setError] = useState<string | null>(null);
 
   const acceptFiles = useCallback(
@@ -22,7 +24,7 @@ export function useModelUpload() {
         return;
       }
       if (!file.name.toLowerCase().endsWith(GLB_EXTENSION)) {
-        setError(".glb ファイルのみ対応しています");
+        setError(t("upload.error.glbOnly"));
         return;
       }
       setError(null);
@@ -33,7 +35,7 @@ export function useModelUpload() {
       // mode was "optimize" from a previous session.
       setMode("preview");
     },
-    [loadModel, setMode]
+    [loadModel, setMode, t]
   );
 
   return { acceptFiles, error };

--- a/app/(v2)/i18n/en.ts
+++ b/app/(v2)/i18n/en.ts
@@ -1,0 +1,101 @@
+import type { Messages } from "./ja";
+
+// English catalog. Typed as `Messages` so every key from `ja.ts` is required.
+export const en: Messages = {
+  "common.noUpload": "* Nothing is uploaded to any server",
+  "common.polygons": "Polygons",
+
+  "header.preview": "Preview",
+  "header.optimize": "Optimize",
+  "header.brandSubtitle": "Preview & optimize glb, offline",
+  "header.modeTabs": "View mode",
+  "header.toDark": "Switch to dark mode",
+  "header.toLight": "Switch to light mode",
+  "header.language": "Switch language",
+
+  "service.heading": "What you can do here",
+  "service.preview.title": "Preview 3D models",
+  "service.preview.body": "Just upload a 3D model to check it — no dedicated app required.",
+  "service.info.title": "Inspect animations & details",
+  "service.info.body":
+    "Play animations and inspect materials, textures, and mesh structure contained in the model.",
+  "service.optimize.title": "Optimization suggestions, applied in one click",
+  "service.optimize.body":
+    "We suggest optimizations for using 3D models on the web and apply them in one click. You can also fine-tune them yourself.",
+
+  "dropzone.title": "Upload a 3D model",
+  "dropzone.hint": "Drag & drop, or click (.glb)",
+  "upload.error.glbOnly": "Only .glb files are supported",
+
+  "viewer.label": "3D view",
+  "viewer.dropHere": "Drop a .glb here",
+  "viewer.dropReplace": "Drop a .glb here to replace",
+  "toolbar.playAnimation": "Play animation",
+  "toolbar.pauseAnimation": "Pause animation",
+  "toolbar.resetView": "Reset view",
+
+  "tabs.label": "Preview info",
+  "tabs.animation": "Animation",
+  "tabs.material": "Material",
+  "tabs.mesh": "Mesh",
+
+  "animation.play": "Play",
+  "animation.pause": "Pause",
+  "animation.seek": "Playback position",
+
+  "material.textures": "Textures",
+  "material.roughness": "Roughness",
+  "material.metalness": "Metalness",
+  "material.optimizeCta": "Optimize materials",
+
+  "mesh.title": "Mesh structure",
+  "mesh.pickHint": "Click in the viewer to select a mesh",
+  "mesh.collapse": "Collapse",
+  "mesh.expand": "Expand",
+  "mesh.optimizeCta": "Optimize polygons",
+
+  "optimize.heading": "You can customize the optimization settings",
+
+  "prune.label": "Remove unused data",
+  "prune.text": "Removes unused data to make the model lighter.",
+  "prune.dataLabel": "Unused data",
+
+  "texture.label": "Texture optimization",
+  "texture.text": "Just pick a max resolution to shrink every image at once.",
+  "texture.note": "* Only images larger than the chosen resolution are adjusted",
+  "texture.currentMax": "Current max resolution",
+  "texture.individual": "Set individually",
+  "texture.maxResolution": "Max resolution",
+  "texture.keep": "No change",
+  "texture.recommendedOption": "{resolution} (recommended)",
+  "texture.resolutionOf": "Resolution of {name}",
+  "texture.delete": "Delete {name}",
+  "texture.restore": "Restore {name}",
+  "texture.chip.min": "Smallest",
+  "texture.chip.recommended": "Recommended",
+  "texture.chip.high": "High quality",
+
+  "polygon.label": "Polygon reduction",
+  "polygon.text": "Reduces the number of faces to make the model lighter (off by default).",
+  "polygon.warning": "* Shape or animation may break",
+  "polygon.reductionRate": "Reduction",
+  "polygon.wireframe": "Show wireframe",
+
+  "summary.calculating": "Calculating…",
+  "summary.save": "Save optimized",
+
+  "model.size": "Size",
+  "model.optimizeCta": "Optimize this model",
+
+  "legacy.open": "Open the previous version",
+
+  "capture.button": "Capture",
+  "capture.dialogLabel": "Capture settings",
+  "capture.light": "Light",
+  "capture.ambient": "Ambient",
+  "capture.directional": "Directional",
+  "capture.shadow": "Add shadow",
+  "capture.shadowOpacity": "Shadow opacity",
+  "capture.transparent": "Transparent background",
+  "capture.save": "Capture & save",
+};

--- a/app/(v2)/i18n/ja.ts
+++ b/app/(v2)/i18n/ja.ts
@@ -1,0 +1,103 @@
+// Japanese message catalog — the source of truth. `Messages` is derived from
+// its shape so `en.ts` must provide every key (missing keys = compile error).
+// `{name}` style placeholders are filled by the `t()` helper.
+export const ja = {
+  "common.noUpload": "※サーバーにアップロードすることはありません",
+  "common.polygons": "ポリゴン数",
+
+  "header.preview": "プレビュー",
+  "header.optimize": "軽量化",
+  "header.brandSubtitle": "オフラインでglbのプレビューと軽量化を",
+  "header.modeTabs": "表示モード",
+  "header.toDark": "ダークモードに切り替え",
+  "header.toLight": "ライトモードに切り替え",
+  "header.language": "言語を切り替え",
+
+  "service.heading": "このサービスでできること",
+  "service.preview.title": "3Dモデルのプレビュー",
+  "service.preview.body": "専用アプリがなくても3Dモデルをアップロードするだけで表示確認ができます。",
+  "service.info.title": "アニメーションや詳細情報の確認",
+  "service.info.body": "3Dモデルに含まれるアニメーションの再生や、マテリアルや使用テクスチャ、メッシュ構造の確認も可能です。",
+  "service.optimize.title": "最適化の提案とワンクリックでの反映",
+  "service.optimize.body":
+    "3Dモデルをウェブで扱う上での最適化をご提案、ワンクリックで反映いただけます。ご自身での調整も可能です。",
+
+  "dropzone.title": "3Dモデルをアップロード",
+  "dropzone.hint": "ドラッグ&ドロップ、またはクリック（.glb）",
+  "upload.error.glbOnly": ".glb ファイルのみ対応しています",
+
+  "viewer.label": "3Dビュー",
+  "viewer.dropHere": "ここに .glb をドロップ",
+  "viewer.dropReplace": "ここに .glb をドロップして差し替え",
+  "toolbar.playAnimation": "アニメーションを再生",
+  "toolbar.pauseAnimation": "アニメーションを停止",
+  "toolbar.resetView": "視点をリセット",
+
+  "tabs.label": "プレビュー情報",
+  "tabs.animation": "アニメーション",
+  "tabs.material": "マテリアル",
+  "tabs.mesh": "メッシュ",
+
+  "animation.play": "再生",
+  "animation.pause": "停止",
+  "animation.seek": "再生位置",
+
+  "material.textures": "テクスチャ",
+  "material.roughness": "粗さ (Roughness)",
+  "material.metalness": "金属感 (Metalness)",
+  "material.optimizeCta": "マテリアルの最適化をする",
+
+  "mesh.title": "メッシュ構造",
+  "mesh.pickHint": "右のビューアーでクリックしてメッシュを選択する",
+  "mesh.collapse": "折りたたむ",
+  "mesh.expand": "展開する",
+  "mesh.optimizeCta": "ポリゴンの最適化をする",
+
+  "optimize.heading": "軽量化の設定はカスタマイズが可能です",
+
+  "prune.label": "未使用データの削除",
+  "prune.text": "使われていないデータを削除して軽量化します。",
+  "prune.dataLabel": "未使用データ",
+
+  "texture.label": "テクスチャの最適化",
+  "texture.text": "最大解像度を選ぶだけで、すべての画像をまとめて縮小します。",
+  "texture.note": "※指定解像度を超えるもののみ調整します",
+  "texture.currentMax": "現在の最大解像度",
+  "texture.individual": "個別で設定する",
+  "texture.maxResolution": "最大解像度",
+  "texture.keep": "変更なし",
+  "texture.recommendedOption": "{resolution}（おすすめ）",
+  "texture.resolutionOf": "{name} の解像度",
+  "texture.delete": "{name} を削除",
+  "texture.restore": "{name} を戻す",
+  "texture.chip.min": "最軽量",
+  "texture.chip.recommended": "おすすめ",
+  "texture.chip.high": "高品質",
+
+  "polygon.label": "ポリゴンの削減",
+  "polygon.text": "面の数を減らして軽くします（既定はオフ）。",
+  "polygon.warning": "※形やアニメーションが崩れる場合があります",
+  "polygon.reductionRate": "削減率",
+  "polygon.wireframe": "ワイヤーフレームで確認",
+
+  "summary.calculating": "計算中…",
+  "summary.save": "軽量化して保存",
+
+  "model.size": "サイズ",
+  "model.optimizeCta": "モデルの軽量化をする",
+
+  "legacy.open": "以前のバージョンを開く",
+
+  "capture.button": "キャプチャ",
+  "capture.dialogLabel": "キャプチャ設定",
+  "capture.light": "ライト",
+  "capture.ambient": "環境光",
+  "capture.directional": "直接光",
+  "capture.shadow": "影をつける",
+  "capture.shadowOpacity": "影の濃さ",
+  "capture.transparent": "背景を透過する",
+  "capture.save": "キャプチャして保存",
+};
+
+export type Messages = typeof ja;
+export type MessageKey = keyof Messages;

--- a/app/(v2)/i18n/useTranslations.ts
+++ b/app/(v2)/i18n/useTranslations.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useCallback } from "react";
+import { useUiStore } from "../store/uiStore";
+import { ja, type MessageKey, type Messages } from "./ja";
+import { en } from "./en";
+
+const dictionaries: Record<"ja" | "en", Messages> = { ja, en };
+
+/**
+ * Returns a `t(key, params?)` translator bound to the current locale. Values may
+ * contain `{name}` placeholders, filled from `params`.
+ */
+export function useTranslations() {
+  const locale = useUiStore((state) => state.locale);
+  const messages = dictionaries[locale];
+
+  return useCallback(
+    (key: MessageKey, params?: Record<string, string | number>) => {
+      let text: string = messages[key];
+      if (params) {
+        for (const [name, value] of Object.entries(params)) {
+          text = text.split(`{${name}}`).join(String(value));
+        }
+      }
+      return text;
+    },
+    [messages]
+  );
+}

--- a/app/(v2)/layout.tsx
+++ b/app/(v2)/layout.tsx
@@ -12,9 +12,11 @@ const brandFont = Space_Grotesk({
   display: "swap",
 });
 
+// Metadata is rendered on the server and can't read the client-persisted
+// locale, so it stays in English (per-locale metadata would need URL routing).
 export const metadata: Metadata = {
   title: "gltf-light",
-  description: "オフラインでglbのプレビューと軽量化を",
+  description: "Preview & optimize glb, offline",
 };
 
 export default function V2Layout({

--- a/app/(v2)/page.tsx
+++ b/app/(v2)/page.tsx
@@ -2,6 +2,7 @@
 
 import { useModelStore } from "./store/modelStore";
 import { useViewerDrop } from "./hooks/useViewerDrop";
+import { useTranslations } from "./i18n/useTranslations";
 import { Header } from "./components/Header";
 import { ServiceInfo } from "./components/ServiceInfo";
 import { FileDropzone } from "./components/FileDropzone";
@@ -17,6 +18,7 @@ import styles from "./styles/page.module.scss";
 export default function V2Page() {
   const hasModel = useModelStore((state) => state.originalBytes !== null);
   const { isDragging, dropProps } = useViewerDrop();
+  const t = useTranslations();
 
   return (
     <>
@@ -30,12 +32,12 @@ export default function V2Page() {
               <ServiceInfo />
               <LegacyLink />
             </aside>
-            <section className={styles.viewer} aria-label="3Dビュー" {...dropProps}>
+            <section className={styles.viewer} aria-label={t("viewer.label")} {...dropProps}>
               <div className={styles.viewerBody}>
                 <FileDropzone variant="hero" />
               </div>
               <Copyright />
-              {isDragging && <div className={styles.dropOverlay}>ここに .glb をドロップ</div>}
+              {isDragging && <div className={styles.dropOverlay}>{t("viewer.dropHere")}</div>}
             </section>
           </>
         )}

--- a/app/(v2)/store/uiStore.ts
+++ b/app/(v2)/store/uiStore.ts
@@ -7,12 +7,18 @@ export type Mode = "preview" | "optimize";
 /** Color theme. Light is the default per the approved design. */
 export type Theme = "light" | "dark";
 
+/** UI language. `ja` is the default; detected from the browser on first visit. */
+export type Locale = "ja" | "en";
+
 interface UiState {
   mode: Mode;
   theme: Theme;
+  locale: Locale;
   setMode: (mode: Mode) => void;
   toggleTheme: () => void;
   setTheme: (theme: Theme) => void;
+  setLocale: (locale: Locale) => void;
+  toggleLocale: () => void;
 }
 
 /**
@@ -26,9 +32,12 @@ export const useUiStore = create<UiState>()(
     (set) => ({
       mode: "preview",
       theme: "light",
+      locale: "ja",
       setMode: (mode) => set({ mode }),
       toggleTheme: () => set((state) => ({ theme: state.theme === "light" ? "dark" : "light" })),
       setTheme: (theme) => set({ theme }),
+      setLocale: (locale) => set({ locale }),
+      toggleLocale: () => set((state) => ({ locale: state.locale === "ja" ? "en" : "ja" })),
     }),
     {
       name: "gltf-light-v2-ui",

--- a/app/(v2)/viewer/CapturePanel.tsx
+++ b/app/(v2)/viewer/CapturePanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import type { StageController } from "./useThreeStage";
+import { useTranslations } from "../i18n/useTranslations";
 import { CameraIcon, CheckIcon } from "../icons";
 import styles from "./CapturePanel.module.scss";
 
@@ -78,6 +79,7 @@ function Check({
 export function CapturePanel({ stage }: { stage: StageController }) {
   const [open, setOpen] = useState(false);
   const [transparent, setTransparent] = useState(false);
+  const t = useTranslations();
 
   return (
     <div className={styles.root}>
@@ -88,17 +90,17 @@ export function CapturePanel({ stage }: { stage: StageController }) {
         onClick={() => setOpen((previous) => !previous)}
       >
         <CameraIcon size={16} />
-        <span className={styles.triggerLabel}>キャプチャ</span>
+        <span className={styles.triggerLabel}>{t("capture.button")}</span>
       </button>
 
       {open && (
-        <div className={styles.panel} role="dialog" aria-label="キャプチャ設定">
-          <p className={styles.heading}>キャプチャ</p>
+        <div className={styles.panel} role="dialog" aria-label={t("capture.dialogLabel")}>
+          <p className={styles.heading}>{t("capture.button")}</p>
 
           <div className={styles.group}>
-            <span className={styles.groupLabel}>ライト</span>
+            <span className={styles.groupLabel}>{t("capture.light")}</span>
             <Slider
-              label="環境光"
+              label={t("capture.ambient")}
               min={0}
               max={3}
               step={0.05}
@@ -106,7 +108,7 @@ export function CapturePanel({ stage }: { stage: StageController }) {
               onChange={stage.setAmbientIntensity}
             />
             <Slider
-              label="直接光"
+              label={t("capture.directional")}
               min={0}
               max={3}
               step={0.05}
@@ -116,10 +118,14 @@ export function CapturePanel({ stage }: { stage: StageController }) {
           </div>
 
           <div className={styles.group}>
-            <Check label="影をつける" checked={stage.shadowEnabled} onChange={stage.setShadowEnabled} />
+            <Check
+              label={t("capture.shadow")}
+              checked={stage.shadowEnabled}
+              onChange={stage.setShadowEnabled}
+            />
             {stage.shadowEnabled && (
               <Slider
-                label="影の濃さ"
+                label={t("capture.shadowOpacity")}
                 min={0}
                 max={1}
                 step={0.05}
@@ -130,12 +136,16 @@ export function CapturePanel({ stage }: { stage: StageController }) {
           </div>
 
           <div className={styles.group}>
-            <Check label="背景を透過する" checked={transparent} onChange={setTransparent} />
+            <Check
+              label={t("capture.transparent")}
+              checked={transparent}
+              onChange={setTransparent}
+            />
           </div>
 
           <button type="button" className={styles.capture} onClick={() => stage.capture({ transparent })}>
             <CameraIcon size={16} />
-            キャプチャして保存
+            {t("capture.save")}
           </button>
         </div>
       )}

--- a/app/(v2)/viewer/ViewerToolbar.tsx
+++ b/app/(v2)/viewer/ViewerToolbar.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations } from "../i18n/useTranslations";
 import { PlayIcon, PauseIcon, RotateIcon } from "../icons";
 import styles from "./ViewerToolbar.module.scss";
 
@@ -10,6 +13,7 @@ interface ViewerToolbarProps {
 
 /** Minimal in-viewer controls: play/pause (when animated) + reset view. */
 export function ViewerToolbar({ hasAnimation, isPlaying, onTogglePlay, onResetView }: ViewerToolbarProps) {
+  const t = useTranslations();
   return (
     <div className={styles.toolbar}>
       {hasAnimation && (
@@ -17,12 +21,17 @@ export function ViewerToolbar({ hasAnimation, isPlaying, onTogglePlay, onResetVi
           type="button"
           className={styles.button}
           onClick={onTogglePlay}
-          aria-label={isPlaying ? "アニメーションを停止" : "アニメーションを再生"}
+          aria-label={isPlaying ? t("toolbar.pauseAnimation") : t("toolbar.playAnimation")}
         >
           {isPlaying ? <PauseIcon size={16} /> : <PlayIcon size={16} />}
         </button>
       )}
-      <button type="button" className={styles.button} onClick={onResetView} aria-label="視点をリセット">
+      <button
+        type="button"
+        className={styles.button}
+        onClick={onResetView}
+        aria-label={t("toolbar.resetView")}
+      >
         <RotateIcon size={16} />
       </button>
     </div>


### PR DESCRIPTION
## 概要

issue #61 の実装。v2 UI を英語対応（i18n）。**設定ベース**（localStorage、URL は変えない）、**ブラウザ言語で自動判定**、legacy は英語のまま据え置き。

## 変更点

- **`app/(v2)/i18n/`**: `ja.ts` をソース辞書とし、`Messages` 型を導出。`en.ts` を `Messages` 型で定義 → **キー欠落はコンパイルエラー**。`useTranslations()` が `t(key, params?)`（`{name}` 補間）を返す。
- **uiStore**: `locale`（"ja" | "en"）を追加（persist）＋ `setLocale` / `toggleLocale`。
- **AppShell**: 初回（未保存時）に `navigator.language` から判定。`<html lang>` を locale に追従。
- **Header**: 言語スイッチ（テーマトグルの隣）。
- 約20コンポーネントの文字列を `t(...)` 化（補間 aria-label・アップロードエラー含む）。v2 metadata はサーバー描画のため英語固定。legacy は不変、GA イベント名も不変。

## QA (Playwright MCP, port 3100)

- ✅ 自動判定: ブラウザ言語 ja → `ja` を検出。
- ✅ EN に切替で全画面が英語化（空状態 / プレビュー各タブ / 軽量化各カード）。
- ✅ 選択がリロード後も維持（`html lang=en`、localStorage `en`）。
- ✅ 補間 aria-label・型によるキー欠落 0。
- ✅ `/legacy` は 200 で不変。console エラー 0 / lint・test(48)・build 全パス。

Closes #61