### PR TITLE
コピーライトの文字サイズ拡大 + 旧版リンクを青で強調

### DIFF
--- a/app/(v2)/components/Copyright.module.scss
+++ b/app/(v2)/components/Copyright.module.scss
@@ -1,8 +1,8 @@
 .copyright {
   margin: 0;
   padding: var(--space-8) 0;
-  font-size: var(--font-size-9);
-  line-height: 12px;
+  font-size: var(--font-size-11);
+  line-height: 14px;
   color: var(--color-text-faint);
   text-align: center;
 }

--- a/app/(v2)/components/LegacyLink.module.scss
+++ b/app/(v2)/components/LegacyLink.module.scss
@@ -3,13 +3,14 @@
   // Push the link to the bottom of the sidebar column, below every card.
   margin-top: auto;
   padding-top: var(--space-8);
-  color: var(--color-text-faint);
-  font-size: var(--font-size-11);
-  line-height: 14px;
+  color: var(--color-highlight);
+  font-weight: 600;
+  font-size: var(--font-size-14);
+  line-height: 18px;
   text-decoration: underline;
   text-underline-offset: 2px;
 
   &:hover {
-    color: var(--color-accent);
+    text-decoration: none;
   }
 }


### PR DESCRIPTION
## 概要

軽微な表示調整2点。

- **コピーライト**（ビュー下部）: フォントサイズを一段階拡大（`font-size-9` → `font-size-11`）。
- **旧バージョンへの案内リンク**（サイドバー下部）: 青文字（`--color-highlight`）＋太字＋一段階大きく（`font-size-14`）して目立たせる。ホバーで下線を外す。

## QA (Playwright, port 3100)

- ✅ 「Open the previous version（以前のバージョンを開く）」が青・太字・大きめで明確に目立つ。
- ✅ コピーライトが一段階拡大。
- ✅ build パス。