### PR TITLE
fix: モード切替でアニメーションの再生/停止状態が維持されない

### DIFF
--- a/app/(v2)/viewer/useThreeStage.ts
+++ b/app/(v2)/viewer/useThreeStage.ts
@@ -397,6 +397,13 @@ export function useThreeStage(displayBytes: ArrayBuffer | null, sourceBytes: Arr
           return;
         }
         const stage = refs.current;
+        // A reflection / mode switch reloads the model but is NOT a fresh
+        // upload; capture the current animation state so it can be preserved
+        // (only a new source resets play state / camera).
+        const isNewSource = sourceBytes !== loadedSourceRef.current;
+        const previousPlaying = isPlayingRef.current;
+        const previousActiveClips = activeClipsRef.current;
+        const previousTime = stage.mixer?.time ?? 0;
         if (stage.model) {
           stage.mixer?.stopAllAction();
           stage.scene.remove(stage.model);
@@ -459,7 +466,7 @@ export function useThreeStage(displayBytes: ArrayBuffer | null, sourceBytes: Arr
 
         // Fit the camera only for a freshly uploaded model — reflections and
         // mode switches keep the current camera.
-        if (sourceBytes !== loadedSourceRef.current) {
+        if (isNewSource) {
           loadedSourceRef.current = sourceBytes;
           const box = new THREE.Box3().setFromObject(model);
           const center = box.getCenter(new THREE.Vector3());
@@ -486,20 +493,33 @@ export function useThreeStage(displayBytes: ArrayBuffer | null, sourceBytes: Arr
             stage.actions.set(clip.name, mixer.clipAction(clip));
             stage.clips.set(clip.name, clip);
           });
-          const first = gltf.animations[0];
-          stage.actions.get(first.name)?.reset().play();
           setAnimations(gltf.animations.map((clip) => ({ name: clip.name, duration: clip.duration })));
-          setActiveClips([first.name]);
-          setDuration(first.duration);
-          setIsPlaying(true);
+
+          // Fresh upload: start the first clip playing. Reflection / mode
+          // switch: keep the user's clips, play/pause state, and position so a
+          // paused preview stays paused after switching tabs.
+          const restored = isNewSource
+            ? []
+            : previousActiveClips.filter((name) => stage.actions.has(name));
+          const active = restored.length > 0 ? restored : [gltf.animations[0].name];
+          active.forEach((name) => stage.actions.get(name)?.reset().play());
+          const playing = isNewSource ? true : previousPlaying;
+          const time = isNewSource ? 0 : previousTime;
+          mixer.setTime(time);
+          setActiveClips(active);
+          setDuration(
+            active.reduce((max, name) => Math.max(max, stage.clips.get(name)?.duration ?? 0), 0)
+          );
+          setIsPlaying(playing);
+          setCurrentTime(time);
         } else {
           stage.mixer = null;
           setAnimations([]);
           setActiveClips([]);
           setDuration(0);
           setIsPlaying(false);
+          setCurrentTime(0);
         }
-        setCurrentTime(0);
       },
       () => {
         // parse error — leave the previous scene untouched


### PR DESCRIPTION
## 概要

プレビュータブでアニメーションを停止して軽量化タブに切り替えると、再びアニメーションが再生されてしまうバグの修正。

## 原因

軽量化タブでは最適化結果を3Dビューへ反映するためモデルを再ロードするが、ロード処理が**常に `setIsPlaying(true)`（先頭クリップを再生）にリセット**していたため、直前の停止状態が失われていた。

## 修正

再生状態のリセットを**新規アップロード時のみ**に限定。反映／モード切替（同一ソースの再ロード）では、直前の**再生/停止状態・アクティブクリップ・再生位置**を復元する（`isPlayingRef` / `activeClipsRef` / 旧 mixer の time を退避して新 mixer に適用）。

## QA (Playwright MCP, port 3100, test.glb)

- ✅ プレビューで**停止** → 軽量化タブへ切替 → **停止のまま**（往復しても維持）。
- ✅ プレビューで**再生** → 軽量化タブへ切替 → **再生のまま**。
- ✅ console エラー 0 / lint・test(48)・build 全パス。